### PR TITLE
[Feat] 라디오 버튼 구현

### DIFF
--- a/src/components/Input.vue
+++ b/src/components/Input.vue
@@ -4,68 +4,116 @@ import { computed } from 'vue'
 const props = defineProps({
   type: {
     type: String,
-    default: 'text' // 'text' 또는 'checkbox'
+    default: 'text', // 'text' | 'checkbox' | 'radio'
   },
-  label: String, // checkbox일 때 라벨
-  placeholder: String
+  label: String, // 체크박스·라디오 옆에 표시할 글자
+  placeholder: { type: String, default: '' }, // input일 때 placeholder
+  name: String, // 라디오 그룹 지정용 (같은 name = 같은 그룹)
+  value: [String, Number, Boolean], // 라디오 버튼 값
+  modelValue: [String, Number, Boolean], // v-model용
+  disabled: Boolean,
 })
 
+const emit = defineEmits(['update:modelValue'])
+
+// 어떤 타입인지에 따라 다른 CSS 클래스 적용 (text, checkbox, radio)
 const inputClasses = computed(() => {
-  if (props.type === 'checkbox') {
-    return 'components-checkbox-base'
-  }
+  if (props.type === 'checkbox') return 'components-checkbox-base'
+  if (props.type === 'radio') return 'components-radio-base'
   return 'input-base'
 })
+
+const onChange = (e) => {
+  if (props.type === 'checkbox') {
+    emit('update:modelValue', e.target.checked)
+  } else if (props.type === 'radio') {
+    emit('update:modelValue', props.value)
+  } else {
+    emit('update:modelValue', e.target.value)
+  }
+}
 </script>
 
 <template>
   <div>
-    <template v-if="type === 'checkbox'">
-      <label class="flex items-center gap-2 cursor-pointer">
-        <input type="checkbox" :class="inputClasses" />
-        {{ label }}
+    <!-- 체크박스 -->
+    <template v-if="props.type === 'checkbox'">
+      <label class="components-label">
+        <input
+          type="checkbox"
+          :class="inputClasses"
+          :checked="!!modelValue"
+          :disabled="disabled"
+          @change="onChange"
+        />
+        <span>{{ label }}</span>
       </label>
     </template>
+
+    <!-- 라디오 -->
+    <template v-else-if="props.type === 'radio'">
+      <label class="components-label">
+        <input
+          type="radio"
+          :name="name"
+          :class="inputClasses"
+          :checked="modelValue === value"
+          :value="value"
+          :disabled="disabled"
+          @change="onChange"
+        />
+        <span>{{ label }}</span>
+      </label>
+    </template>
+
+    <!-- 텍스트 input -->
     <template v-else>
-      <input :class="inputClasses" :placeholder="placeholder" />
+      <input
+        :type="props.type"
+        :class="inputClasses"
+        :placeholder="props.placeholder"
+        :disabled="disabled"
+        :value="modelValue != null ? modelValue : ''"
+        @input="onChange"
+      />
     </template>
   </div>
 </template>
 
 <style scoped>
-/* 일반 input 스타일 */
+/* 공통 label */
+.components-label {
+  @apply flex items-center gap-2 cursor-pointer select-none;
+}
+
+/* 텍스트 input */
 .input-base {
-  @apply
-    px-2.5 py-2.5 rounded 
-    placeholder-gray-400
-    outline-none border-b-2
-    transition-all duration-200
-    focus:border-[#00008C]
-    disabled:bg-gray-100 disabled:cursor-not-allowed;
+  @apply px-2.5 py-2.5 rounded placeholder-gray-400 outline-none border-b-2 transition-all duration-200 focus:border-primary disabled:bg-gray-100 disabled:cursor-not-allowed;
 }
 
-/* 체크박스 기본 스타일 */
+/* 체크박스 */
 .components-checkbox-base {
-  @apply appearance-none w-5 h-5 rounded-sm shadow-sm bg-white border border-gray-300 cursor-pointer transition-all duration-200;
-  position: relative;
+  @apply appearance-none w-5 h-5 rounded-sm shadow-sm bg-white border border-gray-300 cursor-pointer transition-all duration-200 relative;
 }
-
-/* 체크 상태일 때 */
 .components-checkbox-base:checked {
-  border-color: #00008C;
+  @apply border-primary bg-primary;
   box-shadow: 0 0 3px rgba(0, 0, 140, 0.5);
 }
-
-/* 체크 마크 */
 .components-checkbox-base:checked::after {
   content: '';
-  position: absolute;
-  top: 2px;
-  left: 6px;
-  width: 5px;
-  height: 10px;
-  border-right: 2px solid #00008C;
-  border-bottom: 2px solid #00008C;
-  transform: rotate(45deg);
+  @apply absolute w-[5px] h-[10px] border-r-2 border-b-2 border-white rotate-45 top-[2px] left-[6px];
+}
+
+/* 라디오 버튼 */
+.components-radio-base {
+  @apply appearance-none w-5 h-5 rounded-full bg-white border border-gray-300 cursor-pointer transition-all duration-200 relative;
+}
+.components-radio-base:checked {
+  @apply border-primary;
+  box-shadow: 0 0 3px rgba(0, 0, 140, 0.5);
+}
+.components-radio-base:checked::after {
+  content: '';
+  @apply absolute w-[9px] h-[9px] rounded-full bg-primary top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2;
 }
 </style>


### PR DESCRIPTION
## #️⃣ Issue Number
- #39 

## 📝 요약(Summary)
Input 태그의 type 속성으로 text, checkbox, radio 컴포넌트를 사용하면 더 편할 것 같아서 현경이 언니가 만든 Input 컴포넌트를 조금 수정해서 라디오 버튼을 구현했습니다.

### 주요 기능
1. **다양한 타입 지원**
   - `text` : 일반 텍스트 입력
   - `checkbox` : 체크박스
   - `radio` : 라디오 버튼 (같은 name 속성으로 그룹화 가능)

2. **v-model 지원**
   각 타입에 맞게 v-model 연동 가능하도록 구현하였습니다.
   - 텍스트: 입력값
   - 체크박스: boolean 값
   - 라디오: 선택된 값

<br />

사용 방법은 아래와 같습니다.
```
<Input type="text" v-model="textValue" placeholder="이름 입력" />
<Input type="checkbox" v-model="checkedValue" label="동의합니다" />
<Input type="radio" v-model="selectedOption" name="group1" value="option1" label="옵션 1" />
```

## 📸스크린샷
‼️실제로는 입력칸, 체크박스, 라디오 버튼만 존재하고 나머지는 이해를 돕기 위한 요소입니다‼️

![input_component](https://github.com/user-attachments/assets/07f4c200-d568-44b5-8c6f-db4ba64817f1)


## 💬 공유사항

체크박스 배경이 원래 흰색이었는데 사용해보니까 라디오 버튼이랑 구분이 잘 안 되기도 하고 체크가 잘 안 보이는 것 같아서 배경색을 `primary` 색으로 수정하였습니다.