### PR TITLE
[Feat] 드롭다운 컴포넌트 생성

### DIFF
--- a/src/components/Dropdown.vue
+++ b/src/components/Dropdown.vue
@@ -1,0 +1,114 @@
+<script setup>
+import { ref, watch, onMounted, onBeforeUnmount } from 'vue'
+
+const props = defineProps({
+  options: { type: Array, required: true },
+  modelValue: { type: [String, Number], default: null },
+  placeholder: { type: String, default: 'Select...' },
+  width: { type: String, default: 'w-48' },
+})
+
+const emit = defineEmits(['update:modelValue'])
+const isOpen = ref(false)
+const selectedLabel = ref('')
+const dropdownRef = ref(null) // 드롭다운 전체를 참조
+
+const toggleDropdown = () => {
+  isOpen.value = !isOpen.value
+}
+
+const selectOption = (option) => {
+  emit('update:modelValue', option.value)
+  selectedLabel.value = option.label
+  isOpen.value = false
+}
+
+watch(
+  () => props.modelValue,
+  (newVal) => {
+    const found = props.options.find((o) => o.value === newVal)
+    selectedLabel.value = found ? found.label : ''
+  },
+  { immediate: true },
+)
+
+// 외부 클릭 감지
+const handleClickOutside = (event) => {
+  if (dropdownRef.value && !dropdownRef.value.contains(event.target)) {
+    isOpen.value = false
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('click', handleClickOutside)
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('click', handleClickOutside)
+})
+</script>
+
+<template>
+  <div ref="dropdownRef" class="dropdown-container relative inline-block" :class="props.width">
+    <!-- 버튼 -->
+    <button
+      class="dropdown-selected-container flex justify-between items-center w-full"
+      @click="toggleDropdown"
+    >
+      <span>{{ selectedLabel || placeholder }}</span>
+      <span class="dropdown-direction">{{ isOpen ? '△' : '▽' }}</span>
+    </button>
+
+    <!-- 옵션 리스트 -->
+    <ul v-if="isOpen" class="dropdown-list">
+      <li
+        v-for="option in options"
+        :key="option.value"
+        class="dropdown-option"
+        @click="selectOption(option)"
+      >
+        {{ option.label }}
+      </li>
+    </ul>
+  </div>
+</template>
+
+<style scoped>
+.dropdown-container {
+  @apply flex-row;
+}
+
+.dropdown-selected-container {
+  @apply text-left px-2.5 py-2.5 w-full rounded placeholder-gray-400 outline-none border-b-2
+         transition-all duration-200 focus:border-primary disabled:bg-gray-100 disabled:cursor-not-allowed;
+}
+
+.dropdown-direction {
+  @apply ml-2;
+}
+
+.dropdown-list {
+  @apply absolute left-0 pb-1 overflow-y-auto max-h-[60vh] bg-white rounded-md shadow-md w-full z-10;
+
+  /* 웹킷 스크롤바 */
+  &::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  &::-webkit-scrollbar-track {
+    @apply bg-gray-100 rounded;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    @apply bg-gray-300 rounded;
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    @apply bg-gray-400;
+  }
+}
+
+.dropdown-option {
+  @apply px-2.5 py-2.5 rounded hover:bg-gray-200 disabled:bg-gray-100 cursor-pointer;
+}
+</style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -6,19 +6,20 @@ const router = createRouter({
     {
       path: '/admin/signup',
       name: 'adminSignup',
-      component: () => import('@/views/AdminSignupView.vue')
+      component: () => import('@/views/AdminSignupView.vue'),
     },
     {
       path: '/admin/login',
       name: 'adminLogin',
-      component: () => import('@/views/AdminLoginView.vue')
+      component: () => import('@/views/AdminLoginView.vue'),
     },
-    { // 예약 완료 페이지
+    {
+      // 예약 완료 페이지
       path: '/reservation/completed',
       name: 'userReservationCompleted',
-      component: () => import('@/views/ReservationCompletedView.vue')
-    }
-  ]
+      component: () => import('@/views/ReservationCompletedView.vue'),
+    },
+  ],
 })
 
 export default router

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,7 +21,7 @@ export default {
 
         // 기본 컬러
         black: '#000000',
-        white: '#FFFFFF'
+        white: '#FFFFFF',
       },
       fontFamily: {
         'mont-noto': ['Montserrat', 'Noto Sans KR', 'sans-serif'],


### PR DESCRIPTION
## #️⃣ Issue Number
#33 

## 📝 요약(Summary)
재사용 가능한 드롭다운 컴포넌트 생성
- 클릭 시 옵션 리스트 표시/숨김
- 옵션 선택 시 v-model로 값 반영
- 외부 클릭 시 드롭다운 닫힘
- 너비를 props로 지정 가능 (width)
- 옵션 리스트 길이가 길면 max-height + 스크롤 자동 적용

## 📸스크린샷 (선택)

<img src="https://github.com/user-attachments/assets/83dc3490-e5a2-4613-969e-2bfd8bbd061e" width="400" alt="image" />


## 💬 공유사항
- `options` : 드롭다운 옵션 배열 { label, value }
- `modelValue` : 선택된 값, v-model로 바인딩
- `placeholder` : 선택 전 표시할 텍스트
- `width` 드롭다운 너비 Tailwind 클래스

예시 코드
```javascript
<script setup>
import { ref } from 'vue'
import Dropdown from '@/components/Dropdown.vue'

const selected1 = ref(null)
const selected2 = ref(null)

const dropdownOptions = [
  { label: 'Option 1: --------------------', value: 1 },
  { label: 'Option 2: --------------------', value: 2 },
  { label: 'Option 3: --------------------', value: 3 },
  { label: 'Option 4: --------------------', value: 4 },
  { label: 'Option 5: --------------------', value: 5 },
  { label: 'Option 6: --------------------', value: 6 },
  { label: 'Option 7: --------------------', value: 7 },
  { label: 'Option 8: --------------------', value: 8 },
  { label: 'Option 9: --------------------', value: 9 },
]
</script>

<template>
  <div class="p-10">
    <div>
      <p>Selected 1: {{ selected1 }}</p>
      <p>Selected 2: {{ selected2 }}</p>
    </div>
    <div class="flex gap-4">
      <!-- 첫 번째 드롭다운, 너비 w-48 -->
      <Dropdown
        v-model="selected1"
        :options="dropdownOptions"
        placeholder="Dropdown 1"
        width="w-48"
      />

      <!-- 두 번째 드롭다운, 너비 w-72 -->
      <Dropdown
        v-model="selected2"
        :options="dropdownOptions"
        placeholder="Dropdown 2"
        width="w-72"
      />
    </div>
  </div>
</template>
```