### PR TITLE
[Feat] 페이지네이션 컴포넌트 생성

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,10 +1,15 @@
 <script setup>
+import PageNation from './components/PageNation.vue';
 // App.vue는 최상위 컴포넌트
 // 라우터 뷰만 렌더링
 </script>
 
 <template>
   <RouterView />
+  <PageNation
+  :total-items="120"
+  v-model:current-page="page" />
+  
 </template>
 
 <style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,15 +1,10 @@
 <script setup>
-import PageNation from './components/PageNation.vue';
 // App.vue는 최상위 컴포넌트
 // 라우터 뷰만 렌더링
 </script>
 
 <template>
   <RouterView />
-  <PageNation
-  :total-items="120"
-  v-model:current-page="page" />
-  
 </template>
 
 <style>

--- a/src/components/PageNation.vue
+++ b/src/components/PageNation.vue
@@ -1,0 +1,101 @@
+<script setup>
+import { ref, watch, computed } from 'vue'
+
+const props = defineProps({
+  totalItems: { type: Number, required: true }, // 전체 아이템 수
+  itemsPerPage: { type: Number, default: 4 }, 	// 한 페이지당 아이템 수
+  modelValue: { type: Number, default: 1 }, 		// v-model 현재 페이지
+  maxVisiblePages: { type: Number, default: 5 } // 표시할 최대 페이지 버튼 수
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+// 내부 상태 (현재 vue의 currentPage)
+const currentPage = ref(props.modelValue)
+
+// 부모에서 props 변경 시 내부 상태 동기화
+watch(() => props.modelValue, (newVal) => {currentPage.value = newVal})
+
+// 전체 페이지 수 계산
+const totalPages = computed(() => Math.ceil(props.totalItems / props.itemsPerPage))
+
+// 표시할 페이지 범위 계산
+const visiblePages = computed(() => {
+  const total = totalPages.value
+  const max = props.maxVisiblePages
+  const current = currentPage.value
+
+  let start = Math.max(1, current - Math.floor(max / 2))
+  let end = start + max - 1
+  if (end > total) {
+    end = total
+    start = Math.max(1, end - max + 1)
+  }
+
+  return Array.from({ length: end - start + 1 }, (_, i) => start + i)
+})
+
+// 페이지 변경 함수
+const changePage = (page) => {
+  if (page >= 1 && page <= totalPages.value && page !== currentPage.value) {
+    currentPage.value = page
+    emit('update:modelValue', page) // 부모로 반영
+  }
+}
+</script>
+
+<template>
+  <div class="flex justify-center items-center gap-2 mt-8">
+    <!-- 이전 버튼 -->
+    <button
+      class="pagination-btn-base"
+      :disabled="currentPage === 1"
+      @click="changePage(currentPage - 1)"
+    >
+      &lt;
+    </button>
+
+    <!-- 페이지 번호 버튼들 -->
+    <button
+      v-for="page in visiblePages" :key="page" class="pagination-btn-base"
+      :class="{
+        'pagination-btn-click': page === currentPage,
+        'pagination-btn': page !== currentPage
+      }"
+      @click="changePage(page)"
+    >
+      {{ page }}
+    </button>
+
+    <!-- 다음 버튼 -->
+    <button
+      class="pagination-btn-base"
+      :disabled="currentPage === totalPages"
+      @click="changePage(currentPage + 1)"
+    >
+      &gt;
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.pagination-btn-base {
+  @apply min-w-[36px] h-9 rounded-md text-sm text-gray-dark font-medium transition;
+}
+
+.pagination-btn:disabled {
+	@apply opacity-50 cursor-not-allowed;
+}
+
+.pagination-btn-click {
+ @apply bg-primary text-white;
+}
+
+.pagination-btn {
+	@apply bg-white border border-gray-300;
+}
+
+.pagination-btn:hover {
+	@apply bg-gray-200;
+}
+</style>


### PR DESCRIPTION
## #️⃣ Issue Number
- #73 

## 📝 요약(Summary)
페이지네이션 태그입니다. 필요한 뷰 페이지에서 import 후 PageNation 태그에 props 속성 입력해서 사용하면 됩니다.
- 이전/이후 버튼 클릭시 다음 페이지 버튼 선택 적용
- 원하는 페이지 선택 가능 

1. props
   - `total-item` : 전체 아이템 수, 회의실 목록이 52개라면 totalItems=52 (이 값은 required로 무조건 넘겨줘야함)
   - `item-per-page` : 한 페이지에 표시할 아이템 수, 한 페이지당 회의실 카드 10개를 보여주고 싶다면 itemsPerPage=10 (기본값은 4)
   - `max-visible-pages` : 페이지네이션 버튼에서 한 번에 보이는 최대 페이지 수
  
2. emits
- 부모에서 v-model로 currentPage를 넘길 때 예시
자식에서 emit('update:modelValue', page)을 실행하면, 부모의 currentPage가 자동으로 3으로 바뀝니다.


## 📸스크린샷 (선택)
![pagenation](https://github.com/user-attachments/assets/2203a054-5828-4f94-be50-ca697e364e70)


## 💬 공유사항
- 사용 예시 코드
```
<script setup>
import PageNation from './components/PageNation.vue';
import { ref } from 'vue'; 
const currentPage = ref(3);
</script>
```

```
<template>
<PageNation
  :total-items="120"
  v-model="currentPage"
/>
<p>현재 페이지: {{ currentPage }}</p>
</template>
```
