### PR TITLE
[Feat] 예약/신청 이력 상세 페이지, 버튼 컴포넌트 수정

### DIFF
--- a/src/components/Button.vue
+++ b/src/components/Button.vue
@@ -4,7 +4,7 @@ const props = defineProps({
 })
 
 // 모든 버튼에 공통으로 적용될 기본 클래스
-const baseClasses = 'px-12 py-2.5 rounded'
+const baseClasses = 'px-12 py-2.5 rounded-md'
 
 // 테마별로 달라지는 부분만 정의
 const themeClasses = {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -62,6 +62,12 @@ const router = createRouter({
       path: '/myReservation',
       name: 'myReservation',
       component: () => import('@/views/UserMyReservation.vue'),
+    },
+    { // 사용자 예약/신청 이력 상세 페이지
+      path: '/myReservation/:id',
+      name: 'myReservationDetail',
+      component: () => import('@/views/UserMyReservationDetail.vue'),
+      props: true, 
     }
   ],
 })

--- a/src/views/UserMyReservation.vue
+++ b/src/views/UserMyReservation.vue
@@ -7,7 +7,7 @@ import Input from '@/components/Input.vue'
 const router = useRouter()
 
 const goToMyReservationDetail = (id) => {
-  router.push(`/reservation/${id}`)
+  router.push(`/myreservation/${id}`)
 }
 
 /* 상태 */
@@ -38,15 +38,15 @@ const reservations = ref([
     resource_group_name: '회의실 예약', // 리소스 그룹 이름
     startTime: '2025년 10월 8일 14:00', // 시작 시간
     endTime: '2025년 10월 8일 15:00', // 종료 시간
-    thumbnail: 'https://placehold.co/100x100/e2e8f0/64748b?text=IMG',  // 리소스 그룹 썸네일
+    thumbnail: 'https://placehold.co/100x100/e2e8f0/64748b?text=IMG',  // 리소스 썸네일
     status: 'CONFIRMED', // 예약 상태
   },
   {
     id: 1234567891,
     name: '보드게임 동아리',
     resource_group_name: '동아리 모집',
-    startTime: '2025년 10월 8일 14:00', // 시작 시간
-    endTime: '2025년 10월 8일 15:00', // 종료 시간
+    startTime: '2025년 10월 8일 14:00', 
+    endTime: '2025년 10월 8일 15:00', 
     thumbnail: 'https://placehold.co/100x100/e2e8f0/64748b?text=IMG',
     status: 'CANCELLED',
   },
@@ -54,8 +54,8 @@ const reservations = ref([
     id: 1234567892,
     name: '분당선(판교역) 출근',
     resource_group_name: '통근버스 신청',
-    startTime: '2025년 10월 8일 14:00', // 시작 시간
-    endTime: '2025년 10월 8일 15:00', // 종료 시간
+    startTime: '2025년 10월 8일 14:00', 
+    endTime: '2025년 10월 8일 15:00',
     thumbnail: 'https://placehold.co/100x100/e2e8f0/64748b?text=IMG',
     status: 'CANCELLED',
   },
@@ -63,8 +63,8 @@ const reservations = ref([
     id: 1234567893,
     name: '패밀리 디럭스',
     resource_group_name: '캠핑카 이용 신청',
-    startTime: '2025년 10월 8일 14:00', // 시작 시간
-    endTime: '2025년 10월 8일 15:00', // 종료 시간
+    startTime: '2025년 10월 8일 14:00', 
+    endTime: '2025년 10월 8일 15:00',
     thumbnail: 'https://placehold.co/100x100/e2e8f0/64748b?text=IMG',
     status: 'CONFIRMED',
   }
@@ -85,7 +85,7 @@ const reservations = ref([
         </div>
         <div class="reservation-list">
           <a v-for="item in reservations" :key="item.id" class="reservation-item cursor-pointer" @click="goToMyReservationDetail(item.id)">
-            <img :src="item.thumbnail" alt="" class="item-image" />
+            <img :src="item.thumbnail" class="item-image" />
             <div class="item-info">
               <div class="item-header">
                 <h3 class="item-name">{{ item.name }}</h3>
@@ -112,12 +112,12 @@ const reservations = ref([
 
 <style scoped>
 .page-background {
-  @apply min-h-screen bg-white py-8 px-4 font-mont-noto;
+  @apply min-h-screen bg-white py-10 px-4 font-mont-noto;
 }
 
 /* 컨테이너 */
 .content-card {
-  @apply max-w-6xl mx-auto bg-white rounded-2xl shadow p-6;
+  @apply max-w-6xl mx-auto bg-white rounded-2xl shadow p-7;
 }
 
 /* 타이틀 */

--- a/src/views/UserMyReservationDetail.vue
+++ b/src/views/UserMyReservationDetail.vue
@@ -1,0 +1,118 @@
+<script setup>
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+
+/* 목록 페이지로 이동 */
+const goToMyReservation = () => {
+  router.push('/myreservation')
+}
+
+/* 예약 취소 */
+const cancelReservation = () => {
+  if (confirm('이 예약을 취소하시겠습니까?')) {
+    alert('예약이 취소되었습니다.')
+    goToMyReservation()
+  }
+}
+
+/* 예약 데이터 (예시) */
+const reservation = ref({
+  id: 123456789,
+  bookerName: '윤소민',
+  serviceName: '회의실 예약',
+  itemName: '회의실 A',
+  startTime: '2025년 10월 8일 (수) 14:00',
+  endTime: '16:00',
+  status: '예약 확정',
+  thumbnail: 'https://placehold.co/600x400/e2e8f0/64748b?text=IMG',
+  created_at: '2025년 9월 8일 (수) 20:01'
+})
+</script>
+
+<template>
+  <div class="page-background">
+    <div class="page-container">
+      <!-- 이미지 카드 -->
+      <div class="content-card">
+        <h2 class="section-title">예약/신청 상세</h2>
+        <img :src="reservation.thumbnail" alt="예약 이미지" class="thumbnail" />
+      </div>
+
+      <!-- 상세 정보 카드 -->
+      <div class="content-card info-card">
+        <h3 class="info-title">{{ reservation.itemName }}</h3>
+
+        <table class="detail-table">
+          <tbody>
+            <tr><th>예약 번호</th><td>{{ reservation.id }}</td></tr>
+            <tr><th>예약자</th><td>{{ reservation.bookerName }}</td></tr>
+            <tr><th>서비스</th><td>{{ reservation.serviceName }}</td></tr>
+            <tr><th>서비스 항목</th><td>{{ reservation.itemName }}</td></tr>
+            <tr><th>이용 일시</th><td>{{ reservation.startTime }} ~ {{ reservation.endTime }}</td></tr>
+            <tr><th>예약 시각</th><td>{{ reservation.created_at }}</td></tr>
+            <tr><th>예약 상태</th><td>{{ reservation.status }}</td></tr>            
+          </tbody>
+        </table>
+
+        <div class="button-group">
+          <Button @click="goToMyReservation">목록</Button>
+          <Button theme="light" @click="cancelReservation">예약 취소</Button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+/* 페이지 레이아웃 */
+.page-background {
+  @apply min-h-screen bg-white py-10 px-4 font-mont-noto;
+}
+.page-container {
+  @apply max-w-6xl mx-auto flex flex-col md:flex-row gap-6;
+}
+
+/* 카드 */
+.content-card {
+  @apply bg-white rounded-2xl shadow p-7 flex-1;
+}
+
+/* 상세 카드 중앙 정렬 */
+.info-card {
+  @apply flex flex-col justify-center items-center text-center;
+}
+
+/* 타이틀 */
+.section-title {
+  @apply text-xl font-semibold text-text mb-10;
+}
+.info-title {
+  @apply text-3xl font-semibold mb-12 text-primary mt-7;
+}
+
+/* 이미지 */
+.thumbnail {
+  @apply rounded-xl shadow-md w-full h-[450px] object-cover;
+}
+
+/* 상세 테이블 */
+.detail-table {
+  @apply table-auto w-fit border-t border-gray-line text-sm mx-auto;
+}
+.detail-table th {
+  @apply text-gray-dark font-medium py-3 pl-10 text-center text-sm whitespace-nowrap;
+}
+.detail-table td {
+  @apply text-text py-3 pl-16 text-left text-sm font-normal;
+}
+.detail-table tr {
+  @apply border-b border-gray-line;
+}
+
+/* 버튼 그룹 */
+.button-group {
+  @apply mt-12 flex gap-4 justify-center;
+}
+</style>


### PR DESCRIPTION
## #️⃣ Issue Number

- #65
- #32  

## 📝 요약(Summary)

#### 예약/신청 이력 상세 페이지
1.  레이아웃 구성
- 왼쪽 카드: 예약한 서비스 항목 이미지 
- 오른쪽 카드: 예약 또는 신청의 상세 정보

2. 상세 정보 카드 항목
- 예약 번호
- 예약자 이름
- 서비스 이름
- 서비스 항목명
- 이용 일시
- 예약 시각
- 예약 상태

3. 예약 취소 기능
- 예약 취소 버튼 클릭 시 확인 팝업 표시
- 팝업에서 확인 선택 시 → 예약이 취소 처리됨 (추후 기능 구현 예정)
- 취소 후 예약 이력 목록 페이지로 이동

4. 테스트 URL
/myreservation  페이지에서 항목 선택 혹은
/myreservation/1234567892

#### 버튼 컴포넌트 수정
`rounded` -> `rounded-md`
 
## 📸스크린샷 (선택)
<img width="1918" height="861" alt="image" src="https://github.com/user-attachments/assets/86994a35-3785-4f61-b993-ede0a2a0555e" />

## 💬 공유사항

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->