### PR TITLE
[Feat] 신청 관리 페이지 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "vue3-apexcharts": "^1.8.0"
       },
       "devDependencies": {
+        "@tailwindcss/line-clamp": "^0.4.4",
         "@vitejs/plugin-vue": "^6.0.1",
         "autoprefixer": "^10.4.21",
         "postcss": "^8.5.6",
@@ -1449,6 +1450,16 @@
       },
       "peerDependencies": {
         "@svgdotjs/svg.js": "^3.2.4"
+      }
+    },
+    "node_modules/@tailwindcss/line-clamp": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.4.4.tgz",
+      "integrity": "sha512-5U6SY5z8N42VtrCrKlsTAA35gy2VSyYtHWCsg1H87NU1SXnEfekTVlrga9fzUDrrHcGi2Lb5KenUWb4lRQT5/g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
       }
     },
     "node_modules/@types/estree": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "vue3-apexcharts": "^1.8.0"
   },
   "devDependencies": {
+    "@tailwindcss/line-clamp": "^0.4.4",
     "@vitejs/plugin-vue": "^6.0.1",
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",

--- a/src/app.css
+++ b/src/app.css
@@ -44,4 +44,8 @@
   .components-page-title {
     @apply text-[20px] font-medium w-full flex  justify-between;
   }
+
+  .components-white-container {
+    @apply bg-white p-3 mt-3 mb-3 rounded-md;
+  }
 }

--- a/src/components/CompanyDetail.vue
+++ b/src/components/CompanyDetail.vue
@@ -1,0 +1,190 @@
+<script setup>
+import { defineProps } from 'vue'
+import Button from './Button.vue'
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+
+const props = defineProps({
+  company: {
+    type: Object,
+    required: true,
+  },
+})
+
+const goToManagerList = () => {
+  router.push(`/super/companies/${encodeURIComponent(props.company.name)}/managers`)
+}
+
+const goToServiceGroupList = () => {
+  router.push(`/super/companies/${encodeURIComponent(props.company.name)}/services`)
+}
+</script>
+
+<template>
+  <div class="company-container">
+    <!-- 기본 정보 -->
+    <section class="section-block">
+      <h3 class="section-title">기본 정보</h3>
+      <table>
+        <tbody>
+          <tr>
+            <th>기업명</th>
+            <td>{{ company.name }}</td>
+          </tr>
+          <tr>
+            <th>사업자등록번호</th>
+            <td>{{ company.id }}</td>
+          </tr>
+          <tr>
+            <th>도메인</th>
+            <td>
+              <a :href="company.link" target="_blank" class="link">{{ company.link }}</a>
+            </td>
+          </tr>
+          <tr>
+            <th>기업로고</th>
+            <td>
+              <img :src="company.logo" alt="logo" class="company-logo" />
+            </td>
+          </tr>
+          <tr>
+            <th>가입일</th>
+            <td>{{ company.registrationDate }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <hr />
+
+    <!-- 담당자 정보 -->
+    <section class="section-block relative">
+      <h3 class="section-title">담당자 정보</h3>
+      <table>
+        <tbody>
+          <tr>
+            <th>대표 관리자</th>
+            <td>{{ company.administrator }}</td>
+          </tr>
+          <tr>
+            <th>이메일</th>
+            <td>
+              <a :href="`mailto:${company.email}`" class="link">{{ company.email }}</a>
+            </td>
+          </tr>
+          <tr>
+            <th>연락처</th>
+            <td>{{ company.phone }}</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div v-if="company.status" class="link-button" @click="goToManagerList">
+        관리자 계정 목록
+        <img src="/public/assets/icons/ic-arrow-outward.png" />
+      </div>
+    </section>
+
+    <hr />
+
+    <!-- 플랫폼 이용 현황 -->
+    <section v-if="company.status" class="section-block relative">
+      <h3 class="section-title">플랫폼 이용 현황</h3>
+      <table>
+        <tbody>
+          <tr>
+            <th>서비스 그룹 수</th>
+            <td>{{ company.serviceGroups }} 개</td>
+          </tr>
+          <tr>
+            <th>고객 수</th>
+            <td>{{ company.customers }} 명</td>
+          </tr>
+          <tr>
+            <th>최근 로그인</th>
+            <td>{{ company.lastLogin }}</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div class="link-button" @click="goToServiceGroupList">
+        서비스 그룹 목록
+        <img src="/public/assets/icons/ic-arrow-outward.png" />
+      </div>
+    </section>
+    <div v-else>
+      <span class="section-title">추가 전달사항</span>
+      <span class="inline-note"
+        >승인/거절 시 해당 관리자에게 메일이 전송 됩니다. 관리자에게 보낼 메일에 추가적으로 전달할
+        사항이 있다면 입력해 주세요.</span
+      >
+      <textarea> </textarea>
+    </div>
+    <div class="button-container">
+      <Button class="deny-button">거절</Button>
+      <Button>승인</Button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.company-container {
+  @apply bg-white rounded-md shadow p-8 space-y-6;
+}
+
+.section-block {
+  @apply relative;
+}
+
+.section-title {
+  @apply text-lg font-semibold text-gray-800 text-lg mb-2;
+}
+
+.inline-note {
+  @apply text-xs text-gray-dark ml-3;
+}
+table {
+  @apply w-full text-left ml-3;
+}
+
+th {
+  @apply text-gray-700 font-normal w-[150px] py-2 align-top;
+}
+
+td {
+  @apply py-2;
+}
+
+.link {
+  @apply text-blue-600 underline;
+}
+
+.company-logo {
+  @apply h-8 object-contain;
+}
+
+.link-button {
+  @apply flex absolute top-[10px] right-[10px] text-sm cursor-pointer hover:underline;
+}
+
+.link-button img {
+  @apply h-[16px];
+}
+
+textarea {
+  @apply bg-gray-line w-full h-[6rem] mt-3;
+}
+
+.button-container {
+  @apply flex justify-center gap-3;
+}
+
+.deny-button {
+  @apply bg-gray-line text-gray-dark;
+}
+
+.deny-button:hover {
+  @apply bg-gray-deep;
+}
+</style>

--- a/src/components/SuperLayout.vue
+++ b/src/components/SuperLayout.vue
@@ -7,8 +7,12 @@ const goDashboard = () => {
   router.push('/super/dashboard')
 }
 
-const goManagement = () => {
-  router.push('/super/management')
+const goCompanyList = () => {
+  router.push('/super/companies')
+}
+
+const goApplicationList = () => {
+  router.push('/super/applications')
 }
 </script>
 
@@ -25,7 +29,8 @@ const goManagement = () => {
       <div class="sub-menu-section">
         <div class="sub-menu-items-container">
           <div class="sub-menu-item" @click="goDashboard">대시보드</div>
-          <div class="sub-menu-item" @click="goManagement">기업 관리</div>
+          <div class="sub-menu-item" @click="goCompanyList">기업 관리</div>
+          <div class="sub-menu-item" @click="goApplicationList">신청 관리</div>
         </div>
       </div>
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -47,10 +47,6 @@ const router = createRouter({
       props: true,
     },
 
-
-
-    
-
     ////////////////////////////////////////////////////////////////////////////////////////////////////////
     // 기업 관리자 관련 라우터
     ////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -89,26 +85,32 @@ const router = createRouter({
       component: () => import('@/views/super/DashboardView.vue'),
     },
     {
-      path: '/super/management',
-      name: 'superManagement',
+      path: '/super/companies',
+      name: 'superCompanyList',
       component: () => import('@/views/super/CompanyListView.vue'),
     },
     {
-      path: '/super/management/:companyName',
+      path: '/super/companies/:companyName',
       name: 'CompanyDetail',
       component: () => import('@/views/super/CompanyDetailView.vue'),
       props: true,
     },
     {
-      path: '/super/management/:companyName/managers',
+      path: '/super/companies/:companyName/managers',
       name: 'ManagerList',
       component: () => import('@/views/super/ManagerListView.vue'),
       props: true,
     },
     {
-      path: '/super/management/:companyName/services',
+      path: '/super/companies/:companyName/services',
       name: 'ServiceGroupList',
       component: () => import('@/views/super/ServiceGroupListView.vue'),
+      props: true,
+    },
+    {
+      path: '/super/applications',
+      name: 'superApplicationList',
+      component: () => import('@/views/super/ApplicationListView.vue'),
       props: true,
     },
   ],

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -113,6 +113,12 @@ const router = createRouter({
       component: () => import('@/views/super/ApplicationListView.vue'),
       props: true,
     },
+    {
+      path: '/super/applications/:companyId/details',
+      name: 'superApplicationDetails',
+      component: () => import('@/views/super/ApplicationDetailView.vue'),
+      props: true,
+    },
   ],
 })
 

--- a/src/views/super/ApplicationDetailView.vue
+++ b/src/views/super/ApplicationDetailView.vue
@@ -1,0 +1,27 @@
+<script setup>
+import CompanyDetail from '@/components/CompanyDetail.vue'
+import SuperLayout from '@/components/SuperLayout.vue'
+
+const company = {
+  name: '한화시스템',
+  id: '000000',
+  status: false,
+  link: 'https://unibooker.kro.kr/550e8400-e29b-41d4-a716-446655440000',
+  logo: '/public/assets/images/admin_logo.png',
+  registrationDate: '2025.10.05',
+  administrator: '김아영',
+  email: 'ayoung@hanwha.com',
+  phone: '010-1234-5678',
+  serviceGroups: 4,
+  customers: 1234,
+  lastLogin: '2025.10.14 12:30',
+}
+</script>
+
+<template>
+  <SuperLayout>
+    <CompanyDetail :company="company" />
+  </SuperLayout>
+</template>
+
+<style scoped></style>

--- a/src/views/super/ApplicationListView.vue
+++ b/src/views/super/ApplicationListView.vue
@@ -1,18 +1,69 @@
 <script setup>
 import Button from '@/components/Button.vue'
 import SuperLayout from '@/components/SuperLayout.vue'
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+const goToApplicationDetail = (company) => {
+  router.push(`/super/applications/${company.companyId}/details`)
+}
 
 const companies = [
-  { companyName: '넥스트테크', applicationDate: '2025-10-10', administrator: '김민수' },
-  { companyName: '에이아이랩스', applicationDate: '2025-10-11', administrator: '이서연' },
-  { companyName: '블루웨이브', applicationDate: '2025-10-12', administrator: '박지훈' },
-  { companyName: '오픈루프', applicationDate: '2025-10-12', administrator: '최윤아' },
-  { companyName: '하이브소프트', applicationDate: '2025-10-13', administrator: '정우성' },
-  { companyName: '메타브릿지', applicationDate: '2025-10-13', administrator: '홍지민' },
-  { companyName: '코드크래프트', applicationDate: '2025-10-14', administrator: '한지호' },
-  { companyName: '데이터버스', applicationDate: '2025-10-14', administrator: '유지연' },
-  { companyName: '그로스앤컴퍼니', applicationDate: '2025-10-15', administrator: '김도현' },
-  { companyName: '인사이트랩', applicationDate: '2025-10-15', administrator: '오세은' },
+  {
+    companyId: 1,
+    companyName: '넥스트테크',
+    applicationDate: '2025-10-10',
+    administrator: '김민수',
+  },
+  {
+    companyId: 2,
+    companyName: '에이아이랩스',
+    applicationDate: '2025-10-11',
+    administrator: '이서연',
+  },
+  {
+    companyId: 3,
+    companyName: '블루웨이브',
+    applicationDate: '2025-10-12',
+    administrator: '박지훈',
+  },
+  { companyId: 4, companyName: '오픈루프', applicationDate: '2025-10-12', administrator: '최윤아' },
+  {
+    companyId: 5,
+    companyName: '하이브소프트',
+    applicationDate: '2025-10-13',
+    administrator: '정우성',
+  },
+  {
+    companyId: 6,
+    companyName: '메타브릿지',
+    applicationDate: '2025-10-13',
+    administrator: '홍지민',
+  },
+  {
+    companyId: 7,
+    companyName: '코드크래프트',
+    applicationDate: '2025-10-14',
+    administrator: '한지호',
+  },
+  {
+    companyId: 8,
+    companyName: '데이터버스',
+    applicationDate: '2025-10-14',
+    administrator: '유지연',
+  },
+  {
+    companyId: 9,
+    companyName: '그로스앤컴퍼니',
+    applicationDate: '2025-10-15',
+    administrator: '김도현',
+  },
+  {
+    companyId: 10,
+    companyName: '인사이트랩',
+    applicationDate: '2025-10-15',
+    administrator: '오세은',
+  },
 ]
 </script>
 
@@ -44,7 +95,7 @@ const companies = [
                 <td>{{ c.companyName }}</td>
                 <td>{{ c.applicationDate }}</td>
                 <td>{{ c.administrator }}</td>
-                <td><Button>상세 보기</Button></td>
+                <td><Button @click="goToApplicationDetail(c)">상세 보기</Button></td>
               </tr>
             </tbody>
           </table>

--- a/src/views/super/ApplicationListView.vue
+++ b/src/views/super/ApplicationListView.vue
@@ -1,0 +1,97 @@
+<script setup>
+import Button from '@/components/Button.vue'
+import SuperLayout from '@/components/SuperLayout.vue'
+
+const companies = [
+  { companyName: '넥스트테크', applicationDate: '2025-10-10', administrator: '김민수' },
+  { companyName: '에이아이랩스', applicationDate: '2025-10-11', administrator: '이서연' },
+  { companyName: '블루웨이브', applicationDate: '2025-10-12', administrator: '박지훈' },
+  { companyName: '오픈루프', applicationDate: '2025-10-12', administrator: '최윤아' },
+  { companyName: '하이브소프트', applicationDate: '2025-10-13', administrator: '정우성' },
+  { companyName: '메타브릿지', applicationDate: '2025-10-13', administrator: '홍지민' },
+  { companyName: '코드크래프트', applicationDate: '2025-10-14', administrator: '한지호' },
+  { companyName: '데이터버스', applicationDate: '2025-10-14', administrator: '유지연' },
+  { companyName: '그로스앤컴퍼니', applicationDate: '2025-10-15', administrator: '김도현' },
+  { companyName: '인사이트랩', applicationDate: '2025-10-15', administrator: '오세은' },
+]
+</script>
+
+<template>
+  <SuperLayout>
+    <span class="components-page-title">신청 목록</span>
+
+    <div class="components-white-container">
+      <div class="table-container">
+        <!-- header -->
+        <table>
+          <thead>
+            <tr>
+              <th>번호</th>
+              <th>기업명</th>
+              <th>신청일자</th>
+              <th>관리자명</th>
+              <th></th>
+            </tr>
+          </thead>
+        </table>
+
+        <!-- scroll body -->
+        <div class="table-body">
+          <table>
+            <tbody>
+              <tr v-for="(c, i) in companies" :key="i">
+                <td>{{ i + 1 }}</td>
+                <td>{{ c.companyName }}</td>
+                <td>{{ c.applicationDate }}</td>
+                <td>{{ c.administrator }}</td>
+                <td><Button>상세 보기</Button></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </SuperLayout>
+</template>
+
+<style scoped>
+.table-container {
+  @apply w-full;
+}
+
+table {
+  @apply w-full border-collapse;
+}
+
+thead th {
+  @apply text-gray-700 font-semibold bg-gray-100 py-3 px-4 text-center border-b border-gray-300;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.table-body {
+  @apply overflow-y-auto;
+  max-height: calc(100vh - 200px);
+}
+
+tbody td {
+  @apply border-b border-gray-200 py-3 px-4 text-center;
+}
+
+.table-body::-webkit-scrollbar {
+  width: 8px;
+}
+
+.table-body::-webkit-scrollbar-thumb {
+  @apply bg-gray-300 rounded-[4px];
+}
+
+.table-body::-webkit-scrollbar-thumb:hover {
+  @apply bg-gray-400;
+}
+
+tbody tr:hover td {
+  @apply bg-gray-50;
+}
+</style>

--- a/src/views/super/CompanyDetailView.vue
+++ b/src/views/super/CompanyDetailView.vue
@@ -1,6 +1,7 @@
 <script setup>
 import SuperLayout from '@/components/SuperLayout.vue'
 import { useRouter, useRoute } from 'vue-router'
+import CompanyDetail from '@/components/CompanyDetail.vue'
 
 const router = useRouter()
 const route = useRoute()
@@ -9,19 +10,12 @@ const goToCompanies = () => {
   router.push('/super/companies')
 }
 
-const goToManagerList = () => {
-  router.push(`/super/companies/${encodeURIComponent(company.name)}/managers`)
-}
-
-const goToServiceGroupList = () => {
-  router.push(`/super/companies/${encodeURIComponent(company.name)}/services`)
-}
-
 const companyName = route.params.companyName
 
 const company = {
   name: companyName,
   id: '000000',
+  status: true,
   link: 'https://unibooker.kro.kr/550e8400-e29b-41d4-a716-446655440000',
   logo: '/public/assets/images/admin_logo.png',
   registrationDate: '2025.10.05',
@@ -42,98 +36,7 @@ const company = {
 
     <h2 class="title">기업 상세 페이지</h2>
 
-    <div class="company-container">
-      <!-- 기본 정보 -->
-      <section class="section-block">
-        <h3 class="section-title">기본 정보</h3>
-        <table>
-          <tbody>
-            <tr>
-              <th>기업명</th>
-              <td>{{ company.name }}</td>
-            </tr>
-            <tr>
-              <th>사업자등록번호</th>
-              <td>{{ company.id }}</td>
-            </tr>
-            <tr>
-              <th>도메인</th>
-              <td>
-                <a :href="company.link" target="_blank" class="link">{{ company.link }}</a>
-              </td>
-            </tr>
-            <tr>
-              <th>기업로고</th>
-              <td>
-                <img :src="company.logo" alt="logo" class="company-logo" />
-              </td>
-            </tr>
-            <tr>
-              <th>가입일</th>
-              <td>{{ company.registrationDate }}</td>
-            </tr>
-          </tbody>
-        </table>
-      </section>
-
-      <hr />
-
-      <!-- 담당자 정보 -->
-      <section class="section-block relative">
-        <h3 class="section-title">담당자 정보</h3>
-        <table>
-          <tbody>
-            <tr>
-              <th>대표 관리자</th>
-              <td>{{ company.administrator }}</td>
-            </tr>
-            <tr>
-              <th>이메일</th>
-              <td>
-                <a :href="`mailto:${company.email}`" class="link">{{ company.email }}</a>
-              </td>
-            </tr>
-            <tr>
-              <th>연락처</th>
-              <td>{{ company.phone }}</td>
-            </tr>
-          </tbody>
-        </table>
-
-        <div class="link-button" @click="goToManagerList">
-          관리자 계정 목록
-          <img src="/public/assets/icons/ic-arrow-outward.png" />
-        </div>
-      </section>
-
-      <hr />
-
-      <!-- 플랫폼 이용 현황 -->
-      <section class="section-block relative">
-        <h3 class="section-title">플랫폼 이용 현황</h3>
-        <table>
-          <tbody>
-            <tr>
-              <th>서비스 그룹 수</th>
-              <td>{{ company.serviceGroups }} 개</td>
-            </tr>
-            <tr>
-              <th>고객 수</th>
-              <td>{{ company.customers }} 명</td>
-            </tr>
-            <tr>
-              <th>최근 로그인</th>
-              <td>{{ company.lastLogin }}</td>
-            </tr>
-          </tbody>
-        </table>
-
-        <div class="link-button" @click="goToServiceGroupList">
-          서비스 그룹 목록
-          <img src="/public/assets/icons/ic-arrow-outward.png" />
-        </div>
-      </section>
-    </div>
+    <CompanyDetail :company="company" />
   </SuperLayout>
 </template>
 

--- a/src/views/super/CompanyDetailView.vue
+++ b/src/views/super/CompanyDetailView.vue
@@ -5,16 +5,16 @@ import { useRouter, useRoute } from 'vue-router'
 const router = useRouter()
 const route = useRoute()
 
-const goToManagement = () => {
-  router.push('/super/management')
+const goToCompanies = () => {
+  router.push('/super/companies')
 }
 
 const goToManagerList = () => {
-  router.push(`/super/management/${encodeURIComponent(company.name)}/managers`)
+  router.push(`/super/companies/${encodeURIComponent(company.name)}/managers`)
 }
 
 const goToServiceGroupList = () => {
-  router.push(`/super/management/${encodeURIComponent(company.name)}/services`)
+  router.push(`/super/companies/${encodeURIComponent(company.name)}/services`)
 }
 
 const companyName = route.params.companyName
@@ -37,7 +37,7 @@ const company = {
 <template>
   <SuperLayout>
     <div class="path">
-      <span @click="goToManagement">기업 목록</span> > <span>{{ company.name }}</span>
+      <span @click="goToCompanies">기업 목록</span> > <span>{{ company.name }}</span>
     </div>
 
     <h2 class="title">기업 상세 페이지</h2>

--- a/src/views/super/CompanyListView.vue
+++ b/src/views/super/CompanyListView.vue
@@ -17,7 +17,7 @@ const dropdownOptions = [
 ]
 
 const goToCompanyDetail = (company) => {
-  router.push(`/super/management/${encodeURIComponent(company.name)}`)
+  router.push(`/super/companies/${encodeURIComponent(company.name)}`)
 }
 
 const companies = [

--- a/src/views/super/ManagerListView.vue
+++ b/src/views/super/ManagerListView.vue
@@ -7,12 +7,12 @@ const router = useRouter()
 
 const companyName = route.params.companyName
 
-const goToManagement = () => {
-  router.push('/super/management')
+const goToCompanies = () => {
+  router.push('/super/companies')
 }
 
 const goToCompanyDetail = () => {
-  router.push(`/super/management/${encodeURIComponent(companyName)}`)
+  router.push(`/super/companies/${encodeURIComponent(companyName)}`)
 }
 
 // 더미 관리자 & 매니저 데이터
@@ -122,7 +122,7 @@ const managers = [
 <template>
   <SuperLayout>
     <div class="path">
-      <span @click="goToManagement">기업 목록</span> >
+      <span @click="goToCompanies">기업 목록</span> >
       <span @click="goToCompanyDetail">{{ companyName }}</span> >
       <span>관리자 계정 목록</span>
     </div>

--- a/src/views/super/ServiceGroupListView.vue
+++ b/src/views/super/ServiceGroupListView.vue
@@ -7,12 +7,12 @@ const router = useRouter()
 
 const companyName = route.params.companyName
 
-const goToManagement = () => {
-  router.push('/super/management')
+const goToCompanies = () => {
+  router.push('/super/companies')
 }
 
 const goToCompanyDetail = () => {
-  router.push(`/super/management/${encodeURIComponent(companyName)}`)
+  router.push(`/super/companies/${encodeURIComponent(companyName)}`)
 }
 
 const serviceGroups = [
@@ -72,7 +72,7 @@ const serviceGroups = [
 <template>
   <SuperLayout>
     <div class="path">
-      <span @click="goToManagement">기업 목록</span> >
+      <span @click="goToCompanies">기업 목록</span> >
       <span @click="goToCompanyDetail">{{ companyName }}</span> >
       <span>서비스 그룹 목록</span>
     </div>


### PR DESCRIPTION
## #️⃣ Issue Number
#41 

## 📝 요약(Summary)
플랫폼 관리자 - 신청 관리 페이지 구현
- 신청 목록 페이지
- 신청 기업 상세 페이지

기업 상세 컴포넌트 생성

## 📸스크린샷 (선택)
<img width="1913" height="906" alt="image" src="https://github.com/user-attachments/assets/2d6ec2b8-5bbb-4cc8-b7c5-af5a0e4ef226" />
<img width="1915" height="911" alt="image" src="https://github.com/user-attachments/assets/cab7fa15-8e5e-4c8a-85d0-17a41ddbe434" />

## 💬 공유사항
CompanyDetail.vue 컴포넌트를 생성해서 기업 관리에서의 기업 상세 페이지와 신청 관리에서의 신청 상세 페이지에 사용할 수 있게 구현했습니다.

테스트 URL 
- super/applications
- super/applications/[기업아이디]/details