### PR TITLE
[Feat] 서비스 그룹 목록 및 서비스 목록 페이지 구현

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -19,7 +19,7 @@ const router = createRouter({
     {
       path: '/user/mypage',
       name: 'userMypage',
-      component: () => import('@/views/UserMypageView.vue')
+      component: () => import('@/views/UserMypageView.vue'),
     },
     {
       path: '/reservation/completed',
@@ -113,9 +113,21 @@ const router = createRouter({
       props: true,
     },
     {
+      path: '/super/companies/:companyName/services/:serviceGroupName',
+      name: 'ServiceGroupDetail',
+      component: () => import('@/views/super/ServiceGroupDetailView.vue'),
+      props: true,
+    },
+    {
       path: '/super/applications',
       name: 'superApplicationList',
       component: () => import('@/views/super/ApplicationListView.vue'),
+      props: true,
+    },
+    {
+      path: '/super/applications/:companyId/details',
+      name: 'superApplicationDetails',
+      component: () => import('@/views/super/ApplicationDetailView.vue'),
       props: true,
     },
     {

--- a/src/views/super/ServiceGroupDetailView.vue
+++ b/src/views/super/ServiceGroupDetailView.vue
@@ -1,0 +1,188 @@
+<script setup>
+import SuperLayout from '@/components/SuperLayout.vue'
+import { useRoute, useRouter } from 'vue-router'
+
+const route = useRoute()
+const router = useRouter()
+
+const companyName = route.params.companyName
+const serviceGroupName = route.params.serviceGroupName
+const serviceGroup = {
+  status: '활성',
+  type: '회의실',
+  creator: '홍길동',
+  created_at: '2025-10-16',
+  description: '이 서비스 그룹은 회사 내 회의실 예약 관리를 위해 사용됩니다.',
+}
+
+const goToCompanies = () => {
+  router.push('/super/companies')
+}
+
+const goToCompanyDetail = () => {
+  router.push(`/super/companies/${encodeURIComponent(companyName)}`)
+}
+
+const goToServiceDetail = (serviceName) => {
+  router.push(`/super/companies/${encodeURIComponent(companyName)}/services/${serviceName}`)
+}
+
+const goToServiceGroupList = () => {
+  router.push(`/super/companies/${encodeURIComponent(companyName)}/services`)
+}
+
+const goToServiceGroup = () => {
+  router.push(`/super/companies/${encodeURIComponent(companyName)}/services/${serviceGroupName}`)
+}
+
+const services = [
+  {
+    groupName: '회의실 A',
+    name: '회의실 예약',
+    status: '활성',
+    capacity: 10,
+    createdAt: '2025-09-01',
+    createdBy: '김철수',
+    updatedAt: '2025-10-10',
+    updatedBy: '박영희',
+  },
+  {
+    groupName: '회의실 B',
+    name: '회의실 예약',
+    status: '비활성',
+    capacity: 8,
+    createdAt: '2025-08-20',
+    createdBy: '이민호',
+    updatedAt: '2025-09-30',
+    updatedBy: '김영희',
+  },
+  {
+    groupName: '회의실 C',
+    name: '회의실 예약',
+    status: '활성',
+    capacity: 12,
+    createdAt: '2025-07-15',
+    createdBy: '박준형',
+    updatedAt: '2025-10-01',
+    updatedBy: '홍길동',
+  },
+  {
+    groupName: '교육실 A',
+    name: '교육실 예약',
+    status: '활성',
+    capacity: 20,
+    createdAt: '2025-06-10',
+    createdBy: '김민지',
+    updatedAt: '2025-10-05',
+    updatedBy: '이수민',
+  },
+  {
+    groupName: '교육실 B',
+    name: '교육실 예약',
+    status: '비활성',
+    capacity: 15,
+    createdAt: '2025-05-25',
+    createdBy: '최현우',
+    updatedAt: '2025-09-20',
+    updatedBy: '박지훈',
+  },
+]
+</script>
+
+<template>
+  <SuperLayout>
+    <div class="path">
+      <span @click="goToCompanies">기업 목록</span> >
+      <span @click="goToCompanyDetail">{{ companyName }}</span> >
+      <span @click="goToServiceGroupList">서비스 그룹 목록</span> >
+      <span @click="goToServiceGroup">{{ serviceGroupName }}</span>
+    </div>
+    <span class="components-page-title">서비스 그룹 상세</span>
+    <div class="components-white-container">
+      <div>
+        <span class="subtitle">{{ serviceGroupName }}</span>
+      </div>
+      <p class="service-group-info">
+        {{ serviceGroup.type }} | {{ serviceGroup.creator }} | {{ serviceGroup.created_at }}
+      </p>
+      <p class="service-group-info">{{ serviceGroup.description }}</p>
+      <br />
+      <span class="subtitle">서비스 목록</span>
+      <div class="table-body">
+        <table>
+          <thead>
+            <tr>
+              <th>서비스명</th>
+              <th>상태</th>
+              <th>최대 수용 인원</th>
+              <th>생성일</th>
+              <th>생성자</th>
+              <th>수정일</th>
+              <th>수정자</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="(s, i) in services" :key="i">
+              <td>
+                <div class="service-link" @click="goToServiceDetail(s.name)">
+                  {{ s.name }} <img src="/public/assets/icons/ic-arrow-outward.png" />
+                </div>
+              </td>
+              <td>{{ s.status }}</td>
+              <td>{{ s.capacity }}</td>
+              <td>{{ s.createdAt }}</td>
+              <td>{{ s.createdBy }}</td>
+              <td>{{ s.updatedAt }}</td>
+              <td>{{ s.updatedBy }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </SuperLayout>
+</template>
+
+<style scoped>
+.path {
+  @apply text-sm text-gray-600 mb-2;
+}
+.path span {
+  @apply cursor-pointer hover:underline;
+}
+
+.subtitle {
+  @apply text-lg;
+}
+
+.service-group-info {
+  @apply text-sm text-gray-600 mt-1;
+}
+
+.service-link {
+  @apply flex items-center hover:underline cursor-pointer;
+}
+
+table {
+  @apply w-full border-collapse;
+}
+
+.table-body {
+  @apply overflow-y-auto;
+  max-height: calc(100vh - 200px);
+}
+
+th,
+td {
+  @apply border-b border-gray-200 py-3 px-4 text-center;
+}
+th {
+  @apply text-gray-700 font-semibold sticky;
+}
+tr:hover td {
+  @apply bg-gray-50;
+}
+
+td img {
+  @apply h-[16px];
+}
+</style>

--- a/src/views/super/ServiceGroupDetailView.vue
+++ b/src/views/super/ServiceGroupDetailView.vue
@@ -37,8 +37,7 @@ const goToServiceGroup = () => {
 
 const services = [
   {
-    groupName: '회의실 A',
-    name: '회의실 예약',
+    name: '회의실 A',
     status: '활성',
     capacity: 10,
     createdAt: '2025-09-01',
@@ -47,8 +46,7 @@ const services = [
     updatedBy: '박영희',
   },
   {
-    groupName: '회의실 B',
-    name: '회의실 예약',
+    name: '회의실 B',
     status: '비활성',
     capacity: 8,
     createdAt: '2025-08-20',
@@ -57,8 +55,7 @@ const services = [
     updatedBy: '김영희',
   },
   {
-    groupName: '회의실 C',
-    name: '회의실 예약',
+    name: '회의실 C',
     status: '활성',
     capacity: 12,
     createdAt: '2025-07-15',
@@ -67,8 +64,7 @@ const services = [
     updatedBy: '홍길동',
   },
   {
-    groupName: '교육실 A',
-    name: '교육실 예약',
+    name: '교육실 A',
     status: '활성',
     capacity: 20,
     createdAt: '2025-06-10',
@@ -77,8 +73,7 @@ const services = [
     updatedBy: '이수민',
   },
   {
-    groupName: '교육실 B',
-    name: '교육실 예약',
+    name: '교육실 B',
     status: '비활성',
     capacity: 15,
     createdAt: '2025-05-25',

--- a/src/views/super/ServiceGroupListView.vue
+++ b/src/views/super/ServiceGroupListView.vue
@@ -15,6 +15,10 @@ const goToCompanyDetail = () => {
   router.push(`/super/companies/${encodeURIComponent(companyName)}`)
 }
 
+const goToServiceList = (serviceGroupName) => {
+  router.push(`/super/companies/${encodeURIComponent(companyName)}/services/${serviceGroupName}`)
+}
+
 const serviceGroups = [
   {
     groupName: '회의실 예약',
@@ -76,7 +80,7 @@ const serviceGroups = [
       <span @click="goToCompanyDetail">{{ companyName }}</span> >
       <span>서비스 그룹 목록</span>
     </div>
-
+    <span class="components-page-title">서비스 그룹 목록</span>
     <div class="service-group-list-container">
       <table>
         <thead>
@@ -94,7 +98,7 @@ const serviceGroups = [
         <tbody>
           <tr v-for="(s, i) in serviceGroups" :key="i">
             <td>
-              <div class="service-link">
+              <div class="service-link" @click="goToServiceList(s.groupName)">
                 {{ s.groupName }} <img src="/public/assets/icons/ic-arrow-outward.png" />
               </div>
             </td>
@@ -120,7 +124,7 @@ const serviceGroups = [
   @apply cursor-pointer hover:underline;
 }
 .service-group-list-container {
-  @apply bg-white rounded-md shadow p-8 space-y-6 overflow-x-auto;
+  @apply bg-white rounded-md shadow p-8 mt-3 space-y-6 overflow-x-auto;
 }
 table {
   @apply w-full border-collapse;
@@ -138,6 +142,17 @@ tr:hover td {
 
 td img {
   @apply h-[16px];
+}
+.table-body::-webkit-scrollbar {
+  width: 8px;
+}
+
+.table-body::-webkit-scrollbar-thumb {
+  @apply bg-gray-300 rounded-[4px];
+}
+
+.table-body::-webkit-scrollbar-thumb:hover {
+  @apply bg-gray-400;
 }
 
 .service-link {


### PR DESCRIPTION
## #️⃣ Issue Number
#43 

## 📝 요약(Summary)
플랫폼 관리자가 특정 기업의 서비스 그룹 목록과 서비스 목록을 확인할 수 있는 페이지를 구현했습니다.

## 📸스크린샷 (선택)
<img width="1912" height="905" alt="image" src="https://github.com/user-attachments/assets/2428fa8d-fe1e-4b44-9f38-18872ed15be1" />
<img width="1913" height="903" alt="image" src="https://github.com/user-attachments/assets/31df59b7-d3e2-4873-a2fc-477f7a66704d" />

## 💬 공유사항
서비스 그룹과 서비스에 대한 상태 변경이 가능하게 추후 구현할 예정입니다.