### PR TITLE
[Style] 플랫폼 관리자 페이지 테이블 전역 스타일

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -48,4 +48,40 @@
   .components-white-container {
     @apply bg-white p-3 mt-3 mb-3 rounded-md;
   }
+
+  /* 플랫폼 관리자 페이지 테이블 스타일 */
+  .components-super-table-container {
+    @apply w-full overflow-y-auto border border-gray-200 rounded-lg;
+    max-height: calc(100vh - 200px);
+  }
+
+  .components-super-table {
+    @apply w-full border-collapse table-auto;
+  }
+
+  .components-super-table thead th {
+    @apply bg-gray-100 text-gray-700 font-semibold py-3 px-4 text-center border-b border-gray-300;
+    position: sticky;
+    top: 0;
+    z-index: 1;
+  }
+
+  .components-super-table tbody td {
+    @apply border-b border-gray-200 py-3 px-4 text-center;
+  }
+
+  .components-super-table tbody tr:hover td {
+    @apply bg-gray-100;
+  }
+
+  /* 스크롤바 */
+  .components-super-table-container::-webkit-scrollbar {
+    width: 8px;
+  }
+  .components-super-table-container::-webkit-scrollbar-thumb {
+    @apply bg-gray-300 rounded-[4px];
+  }
+  .components-super-table-container::-webkit-scrollbar-thumb:hover {
+    @apply bg-gray-400;
+  }
 }


### PR DESCRIPTION
## #️⃣ Issue Number
#99 

## 📝 요약(Summary)
플랫폼 관리자 페이지에서 사용하는 테이블의 스타일을 전역으로 지정했습니다.

## 📸스크린샷 (선택)
<img width="1905" height="907" alt="image" src="https://github.com/user-attachments/assets/68c26fc7-2d2c-4a19-a2cb-525e721ae674" />


## 💬 공유사항
사용할 때는 다음과 같이 클래스명을 지정하면 됩니다.
```html
<div class="components-super-table-container">
        <table class="components-super-table">
        <table/>
<div/>
```