### PR TITLE
[Feat] 알림 드롭다운 추가

### DIFF
--- a/src/components/AdminLayout.vue
+++ b/src/components/AdminLayout.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref } from 'vue'
+import NotificationDropdown from '@/components/NotificationDropdown.vue'
 
 // 예시 서비스 그룹 목록입니다.
 const services = ref([
@@ -31,6 +32,19 @@ const toggleDropdown = (index) => {
 // 드롭다운 메뉴 선택
 const selectMenuItem = (serviceIndex, menu) => {
   selectedMenuItems.value[serviceIndex] = menu
+}
+
+// 알림 관련 상태, 예시
+const isDropdownOpen = ref(false)
+const notifications = ref([
+  { id: 1, message: '신규 기업 회원가입 요청이 도착했습니다.', time: '2분 전' },
+  { id: 2, message: '서버 점검이 내일 오전 9시에 예정되어 있습니다.', time: '1시간 전' },
+  { id: 3, message: '신청서가 검토 완료되었습니다.', time: '어제' },
+])
+
+// 알림 아이콘 클릭 토글
+const notiToggleDropdown = () => {
+  isDropdownOpen.value = !isDropdownOpen.value
 }
 </script>
 
@@ -98,7 +112,10 @@ const selectMenuItem = (serviceIndex, menu) => {
         <div class="admin-badge">
           <img src="/public/assets/images/admin_logo.png" alt="기업 로고 이미지" />
           <span>김아영 관리자님</span>
-          <img src="/public/assets/icons/ic-new-notify.png" alt="알림 이미지" />
+          <button @click.stop="notiToggleDropdown" class="super-notify-btn">
+            <img src="/assets/icons/ic-new-notify.png" alt="알림 아이콘" class="notify-icon" />
+          </button>
+          <NotificationDropdown type="admin" v-if="isDropdownOpen" :notifications="notifications" @close="isDropdownOpen = false"/>
         </div>
       </div>
       <div class="content-slot">
@@ -176,7 +193,7 @@ const selectMenuItem = (serviceIndex, menu) => {
 }
 
 .admin-badge {
-  @apply bg-white flex items-center rounded-[20px] overflow-hidden px-[12px] py-[6px] text-xs text-[#7D7D7D] font-medium cursor-pointer;
+  @apply bg-white flex items-center rounded-[20px] px-[12px] py-[6px] text-xs text-[#7D7D7D] font-medium cursor-pointer relative;
 }
 
 .admin-badge img:first-child {

--- a/src/components/NotificationDropdown.vue
+++ b/src/components/NotificationDropdown.vue
@@ -6,13 +6,9 @@ const props = defineProps({
     type: Array,
     default: () => [],
   },
-  type: { // super / admin / user
+  type: { // super / admin
     type: String,
     required: true,
-  },
-  companySlug: { // user일 경우 필요
-    type: String,
-    default: '',
   },
 })
 
@@ -25,9 +21,6 @@ const goToNotificationPage = () => {
       break
     case 'admin':
       target = '/admin/notification'
-      break
-    case 'user':
-      if (props.companySlug) target = `/c/${props.companySlug}/notification`
       break
   }
 

--- a/src/components/NotificationDropdown.vue
+++ b/src/components/NotificationDropdown.vue
@@ -60,7 +60,7 @@ const goToNotificationPage = () => {
 
 <style scoped>
 .notification-dropdown-container {
-  @apply absolute top-[110%] right-0 mt-2 w-64 bg-white rounded-md shadow-md z-50 border border-gray-100;
+  @apply absolute top-[110%] right-0 mt-2 w-60 bg-white rounded-md shadow-md z-50 border border-gray-100;
   animation: dropdown-appear 0.2s ease-out;
 }
 

--- a/src/components/NotificationDropdown.vue
+++ b/src/components/NotificationDropdown.vue
@@ -30,7 +30,9 @@ const goToNotificationPage = () => {
 </script>
 
 <template>
-  <div class="notification-dropdown-container">
+  <div class="notification-dropdown-container relative">
+    <div class="notification-tail" />
+
     <div v-if="notifications.length > 0">
       <ul class="notification-dropdown-list">
         <li
@@ -45,7 +47,7 @@ const goToNotificationPage = () => {
     </div>
 
     <div v-else class="notification-dropdown-empty">
-      <p>새로운 알림이 없습니다.</p>
+      <p>No new notifications</p>
     </div>
 
     <div class="notification-dropdown-footer">
@@ -58,33 +60,48 @@ const goToNotificationPage = () => {
 
 <style scoped>
 .notification-dropdown-container {
-  @apply absolute top-full right-0 mt-2 w-60 bg-white rounded-md shadow-md z-10;
+  @apply absolute top-[110%] right-0 mt-2 w-64 bg-white rounded-md shadow-md z-50 border border-gray-100;
+  animation: dropdown-appear 0.2s ease-out;
+}
+
+.notification-tail {
+  @apply absolute top-[-6px] right-4 w-3 h-3 bg-white border-l border-t border-gray-200 rotate-45;
+}
+
+@keyframes dropdown-appear {
+  from {
+    opacity: 0;
+    transform: translateY(-8px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
 }
 
 .notification-dropdown-list {
   @apply max-h-[60vh] overflow-y-auto;
-
-  &::-webkit-scrollbar {
-    width: 8px;
-  }
-  &::-webkit-scrollbar-thumb {
-    @apply bg-gray-300 rounded;
-  }
-  &::-webkit-scrollbar-thumb:hover {
-    @apply bg-gray-400;
-  }
+}
+.notification-dropdown-list::-webkit-scrollbar {
+  width: 8px;
+}
+.notification-dropdown-list::-webkit-scrollbar-thumb {
+  @apply bg-gray-300 rounded;
+}
+.notification-dropdown-list::-webkit-scrollbar-thumb:hover {
+  @apply bg-gray-400;
 }
 
 .notification-dropdown-item {
-  @apply px-3 py-2.5 border-b border-gray-100 hover:bg-gray-100 cursor-pointer transition-colors;
+  @apply px-3 py-2.5 border-b border-gray-100 hover:bg-gray-50 cursor-pointer transition-colors;
 }
 
 .notification-message {
-  @apply text-xs text-text truncate font-normal;
+  @apply text-xs text-gray-800 truncate font-normal;
 }
 
 .notification-time {
-  @apply text-xs text-gray-dark/40 mt-0.5 block font-normal;
+  @apply text-[11px] text-gray-400 mt-0.5 block font-normal;
 }
 
 .notification-dropdown-empty {
@@ -96,14 +113,6 @@ const goToNotificationPage = () => {
 }
 
 .notification-dropdown-button {
-  @apply w-full text-center py-2 text-xs font-medium text-white bg-gray-dark hover:bg-gray-dark transition-colors cursor-pointer;
-}
-
-.super-notify-btn {
-  @apply relative flex items-center justify-center w-8 h-8 bg-transparent border-none cursor-pointer;
-}
-
-.notify-icon {
-  @apply w-5 h-5 object-contain;
+  @apply w-full text-center py-2 text-xs font-medium text-white bg-gray-dark hover:bg-gray-700 transition-colors cursor-pointer;
 }
 </style>

--- a/src/components/NotificationDropdown.vue
+++ b/src/components/NotificationDropdown.vue
@@ -1,0 +1,116 @@
+<script setup>
+const emit = defineEmits(['close'])
+
+const props = defineProps({
+  notifications: {
+    type: Array,
+    default: () => [],
+  },
+  type: { // super / admin / user
+    type: String,
+    required: true,
+  },
+  companySlug: { // user일 경우 필요
+    type: String,
+    default: '',
+  },
+})
+
+const goToNotificationPage = () => {
+  let target = '/notification'
+
+  switch (props.type) {
+    case 'super':
+      target = '/super/notification'
+      break
+    case 'admin':
+      target = '/admin/notification'
+      break
+    case 'user':
+      if (props.companySlug) target = `/c/${props.companySlug}/notification`
+      break
+  }
+
+  window.location.href = target
+  emit('close')
+}
+</script>
+
+<template>
+  <div class="notification-dropdown-container">
+    <div v-if="notifications.length > 0">
+      <ul class="notification-dropdown-list">
+        <li
+          v-for="item in notifications"
+          :key="item.id"
+          class="notification-dropdown-item"
+        >
+          <p class="notification-message">{{ item.message }}</p>
+          <span class="notification-time">{{ item.time }}</span>
+        </li>
+      </ul>
+    </div>
+
+    <div v-else class="notification-dropdown-empty">
+      <p>새로운 알림이 없습니다.</p>
+    </div>
+
+    <div class="notification-dropdown-footer">
+      <button @click="goToNotificationPage" class="notification-dropdown-button">
+        전체 알림 보기
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.notification-dropdown-container {
+  @apply absolute top-full right-0 mt-2 w-60 bg-white rounded-md shadow-md z-10;
+}
+
+.notification-dropdown-list {
+  @apply max-h-[60vh] overflow-y-auto;
+
+  &::-webkit-scrollbar {
+    width: 8px;
+  }
+  &::-webkit-scrollbar-thumb {
+    @apply bg-gray-300 rounded;
+  }
+  &::-webkit-scrollbar-thumb:hover {
+    @apply bg-gray-400;
+  }
+}
+
+.notification-dropdown-item {
+  @apply px-3 py-2.5 border-b border-gray-100 hover:bg-gray-100 cursor-pointer transition-colors;
+}
+
+.notification-message {
+  @apply text-xs text-text truncate font-normal;
+}
+
+.notification-time {
+  @apply text-xs text-gray-dark/40 mt-0.5 block font-normal;
+}
+
+.notification-dropdown-empty {
+  @apply px-4 py-6 text-center text-gray-500 text-sm;
+}
+
+.notification-dropdown-footer {
+  @apply border-t border-gray-100;
+}
+
+.notification-dropdown-button {
+  @apply w-full text-center py-2 text-xs font-medium text-white bg-gray-dark hover:bg-gray-dark transition-colors cursor-pointer;
+}
+
+.super-notify-btn {
+  @apply relative flex items-center justify-center w-8 h-8 bg-transparent border-none cursor-pointer;
+}
+
+.notify-icon {
+  @apply w-5 h-5 object-contain;
+}
+</style>

--- a/src/components/SuperLayout.vue
+++ b/src/components/SuperLayout.vue
@@ -32,8 +32,6 @@ const notifications = ref([
 const toggleDropdown = () => {
   isDropdownOpen.value = !isDropdownOpen.value
 }
-
-
 </script>
 
 <template>

--- a/src/components/SuperLayout.vue
+++ b/src/components/SuperLayout.vue
@@ -2,6 +2,9 @@
 import { RouterView, useRouter } from 'vue-router'
 import { ref } from 'vue'
 import { useRoute } from 'vue-router'
+import NotificationDropdown from '@/components/NotificationDropdown.vue'
+
+
 
 const route = useRoute()
 const router = useRouter()
@@ -19,6 +22,20 @@ const goMenu = (path) => {
   router.push(path)
   selectedMenu.value = path
 }
+
+// 알림 관련 상태, 예시
+const isDropdownOpen = ref(false)
+const notifications = ref([
+  { id: 1, message: '신규 기업 회원가입 요청이 도착했습니다.', time: '2분 전' },
+  { id: 2, message: '서버 점검이 내일 오전 9시에 예정되어 있습니다.', time: '1시간 전' },
+  { id: 3, message: '신청서가 검토 완료되었습니다.', time: '어제' },
+])
+// 알림 아이콘 클릭 토글
+const toggleDropdown = () => {
+  isDropdownOpen.value = !isDropdownOpen.value
+}
+
+
 </script>
 
 <template>
@@ -58,7 +75,10 @@ const goMenu = (path) => {
         <div class="super-badge">
           <img src="/public/assets/images/unibooker_blue_logo.svg" alt="기업 로고 이미지" />
           <span>홍서연 운영자님</span>
-          <img src="/public/assets/icons/ic-new-notify.png" alt="알림 이미지" />
+          <button @click.stop="toggleDropdown" class="super-notify-btn">
+            <img src="/assets/icons/ic-new-notify.png" alt="알림 아이콘" class="notify-icon" />
+          </button>
+          <NotificationDropdown type="super" v-if="isDropdownOpen" :notifications="notifications" @close="isDropdownOpen = false" />
         </div>
       </div>
       <div class="content-slot">
@@ -136,7 +156,7 @@ const goMenu = (path) => {
 }
 
 .super-badge {
-  @apply bg-white flex items-center rounded-[20px] overflow-hidden px-[12px] py-[6px] text-xs text-[#7D7D7D] font-medium cursor-pointer;
+  @apply bg-white flex items-center rounded-[20px] px-[12px] py-[6px] text-xs text-[#7D7D7D] font-medium cursor-pointer relative;
 }
 
 .super-badge img:first-child {

--- a/src/components/SuperLayout.vue
+++ b/src/components/SuperLayout.vue
@@ -4,8 +4,6 @@ import { ref } from 'vue'
 import { useRoute } from 'vue-router'
 import NotificationDropdown from '@/components/NotificationDropdown.vue'
 
-
-
 const route = useRoute()
 const router = useRouter()
 const selectedMenu = ref(route.path)


### PR DESCRIPTION
## #️⃣ Issue Number
- #16 

## 📝 요약(Summary)
알림 이모지 클릭할때 나오는 알림 드롭다운 추가했습니다.

### 적용 페이지
- 플랫폼 관리자 페이지 
- 기업 관리자 페이지

사용자 페이지는 알림 목록 페이지로 바로 이동하는게 자연스러울것같아 넣지 않았습니다.

## 📸스크린샷
<img width="1919" height="857" alt="image" src="https://github.com/user-attachments/assets/49bc301a-e072-4888-92e3-fd436684c4e8" />

## 💬 공유사항
### !!!플랫폼 관리자 페이지 레이아웃(SuperLayout.vue), 기업 관리자 페이지 레이아웃(AdminLayout.vue) 수정했으니 확인 부탁드릴게요!!!

- 수정 전
```
.admin-badge {
  @apply bg-white flex items-center rounded-[20px] overflow-hidden px-[12px] py-[6px] text-xs text-[#7D7D7D] font-medium cursor-pointer;
}
```

- 수정 후
```
.admin-badge {
@apply bg-white flex items-center rounded-[20px] px-[12px] py-[6px] text-xs text-[#7D7D7D] font-medium cursor-pointer relative;
}
```

수정한 이유: overflow-hidden 때문에 드롭다운이 안보임