### PR TITLE
[Feat] 관리자 정보 조회/수정 로직 구현

### DIFF
--- a/src/components/AccountManageModal.vue
+++ b/src/components/AccountManageModal.vue
@@ -1,0 +1,249 @@
+<script setup>
+import { ref, watch } from 'vue'
+import { managerInfoEdit, getManagerInfo } from '@/services/admin/admin_api'
+
+const props = defineProps({
+  open: Boolean,
+  userData: Object,
+})
+const emit = defineEmits(['close'])
+
+const mode = ref('view') // view | edit | password
+
+// 수정용 임시 데이터 (수정 모드에서 사용)
+const editInfo = ref({
+  businessNumber: '',
+  name: '',
+  phone: '',
+  logoFile: null,
+  logoUrl: '', // 기존 로고 URL
+})
+
+// props.userData가 바뀌면 editInfo에 반영 (모달 열 때 초기화용)
+watch(
+  () => props.userData,
+  (newVal) => {
+    if (!newVal) return // userData가 아직 없으면 아무 것도 안 함
+    editInfo.value = {
+      businessNumber: newVal.businessNumber || '',
+      name: newVal.name || '',
+      phone: newVal.phone || '',
+      logoFile: null,
+      logoUrl: newVal.logo || '/public/assets/images/admin_logo.png',
+    }
+  },
+  { immediate: true },
+)
+
+// 수정 모드 진입
+const enterEditMode = () => {
+  mode.value = 'edit'
+}
+
+// 파일 선택 처리
+const handleFileChange = (e) => {
+  const file = e.target.files[0]
+  if (file) {
+    editInfo.value.logoFile = file
+    editInfo.value.logoUrl = URL.createObjectURL(file)
+  }
+}
+
+// 수정 완료 처리
+const handleEditSubmit = async () => {
+  try {
+    const payload = {
+      name: editInfo.value.name,
+      phone: editInfo.value.phone,
+    }
+
+    // 서버에 수정 요청
+    await managerInfoEdit(payload)
+
+    // 서버에서 최신 데이터 가져오기
+    const response = await getManagerInfo()
+    Object.assign(props.userData, response.data) // props.userData 직접 업데이트
+
+    // 모드 전환
+    mode.value = 'view'
+    alert('수정이 완료되었습니다.')
+  } catch (err) {
+    alert('수정에 실패했습니다.')
+    console.error(err)
+  }
+}
+
+// 서비스 탈퇴
+const handleWithdraw = () => {
+  if (confirm('정말 탈퇴하시겠습니까?')) {
+    alert('탈퇴 완료되었습니다.')
+    emit('close')
+  }
+}
+
+// 전화번호 입력 시 하이픈 자동 추가
+const formatPhoneNumber = (e) => {
+  let input = e.target.value.replace(/\D/g, '') // 숫자만 남기기
+  input = input.slice(0, 11) // 최대 11자리 제한
+
+  if (input.length > 3 && input.length <= 7) {
+    input = input.replace(/(\d{3})(\d+)/, '$1-$2')
+  } else if (input.length > 7) {
+    input = input.replace(/(\d{3})(\d{4})(\d+)/, '$1-$2-$3')
+  }
+
+  e.target.value = input
+  editInfo.value.phone = input
+}
+</script>
+
+<template>
+  <Modal :open="props.open" @close="emit('close')">
+    <div class="modal-container">
+      <!-- 보기 모드 -->
+      <template v-if="mode === 'view'">
+        <div class="modal-header">
+          <h3>내 계정관리</h3>
+          <span class="cursor-pointer" @click="enterEditMode">수정</span>
+        </div>
+
+        <div class="modal-input-section">
+          <label>기업명</label>
+          <span>{{ userData?.companyName }}</span>
+        </div>
+        <div class="modal-input-section">
+          <label>사업자등록번호</label>
+          <span>{{ userData?.businessNumber }}</span>
+        </div>
+        <div class="modal-input-section">
+          <label>이메일</label>
+          <span>{{ userData?.email }}</span>
+        </div>
+        <div class="modal-input-section">
+          <label>이름</label>
+          <span>{{ userData?.name }}</span>
+        </div>
+        <div class="modal-input-section">
+          <label>연락처</label>
+          <span>{{ userData?.phone }}</span>
+        </div>
+        <div class="modal-input-section">
+          <label>기업로고</label>
+          <img
+            class="modal-logo-image"
+            src="/public/assets/images/admin_logo.png"
+            alt="기업로고 이미지"
+          />
+        </div>
+
+        <div class="modal-button-container">
+          <Button @click="handleWithdraw" theme="gray" size="sm">서비스 탈퇴</Button>
+          <Button size="sm" @click="mode = 'password'">비밀번호 변경</Button>
+        </div>
+      </template>
+
+      <!-- 수정 모드 -->
+      <template v-else-if="mode === 'edit'">
+        <div class="modal-header">
+          <h3>내 계정 수정</h3>
+        </div>
+
+        <div class="modal-input-section">
+          <label>이름</label>
+          <input v-model="editInfo.name" type="text" class="modal-input" />
+        </div>
+        <div class="modal-input-section">
+          <label>연락처</label>
+          <input
+            v-model="editInfo.phone"
+            type="text"
+            class="modal-input"
+            @input="formatPhoneNumber"
+          />
+        </div>
+        <div class="modal-input-section">
+          <label>기업로고</label>
+          <input @change="handleFileChange" type="file" class="modal-input-file" />
+        </div>
+
+        <div class="modal-button-container">
+          <Button theme="gray" size="sm" @click="mode = 'view'">취소</Button>
+          <Button size="sm" @click="handleEditSubmit">완료</Button>
+        </div>
+      </template>
+
+      <!-- 비밀번호 변경 모드 -->
+      <template v-else-if="mode === 'password'">
+        <div class="modal-header">
+          <h3>비밀번호 변경</h3>
+        </div>
+
+        <div class="modal-input-section">
+          <label>기존 비밀번호</label>
+          <input type="password" class="modal-input" />
+        </div>
+        <div class="modal-input-section">
+          <label>새 비밀번호</label>
+          <input type="password" class="modal-input" />
+        </div>
+        <div class="modal-input-section">
+          <label>새 비밀번호 확인</label>
+          <input type="password" class="modal-input" />
+        </div>
+
+        <div class="modal-button-container">
+          <Button theme="gray" size="sm" @click="mode = 'view'">취소</Button>
+          <Button size="sm">변경하기</Button>
+        </div>
+      </template>
+    </div>
+  </Modal>
+</template>
+
+<style scoped>
+.modal-container {
+  @apply p-[20px] flex flex-col overflow-y-auto max-h-[600px] min-w-[400px];
+}
+
+h3 {
+  @apply text-[18px] font-medium mb-[3px];
+}
+
+.modal-input-section {
+  @apply flex justify-between items-center mt-[15px] mb-[5px];
+}
+
+label,
+.modal-input-section > span {
+  @apply text-[14px] text-black;
+}
+
+.modal-button-container {
+  @apply flex gap-2 mt-[45px];
+}
+
+.modal-button-container button {
+  @apply flex-1 h-[40px] font-normal rounded-[3px];
+}
+
+.modal-header {
+  @apply flex justify-between items-center mb-[20px];
+}
+
+.modal-header span {
+  @apply text-[12px] text-gray-dark cursor-pointer hover:text-[#CE0202];
+}
+
+.modal-logo-image {
+  @apply h-[50px] border border-gray-deep;
+}
+
+.modal-input,
+.modal-input-file {
+  @apply bg-gray-line px-[12px] py-[8px] text-[14px] rounded-[3px];
+}
+
+.modal-input-file {
+  @apply w-[193px] text-[12px] cursor-pointer;
+}
+</style>

--- a/src/components/AccountManageModal.vue
+++ b/src/components/AccountManageModal.vue
@@ -8,7 +8,7 @@ const props = defineProps({
 })
 const emit = defineEmits(['close'])
 
-const mode = ref('view') // view | edit | password
+const mode = ref('view') // view | edit | password | withdraw
 
 // 프로필 정보 수정용 임시 데이터
 const editInfo = ref({
@@ -23,8 +23,34 @@ const editInfo = ref({
 const passwordInfo = ref({
   currentPassword: '',
   newPassword: '',
-  confirmPassword: ''
+  confirmPassword: '',
 })
+
+// 탈퇴용 임시 데이터
+const withdrawInfo = ref({
+  password: '',
+  reason: '',
+})
+
+// 탈퇴 요청
+const handleWithdrawSubmit = async () => {
+  if (!withdrawInfo.value.password) {
+    alert('비밀번호를 입력해주세요.')
+    return
+  }
+  try {
+    // 예시: 실제 서버 API 호출
+    await adminApi.resetPassword({
+      password: withdrawInfo.value.password,
+      reason: withdrawInfo.value.reason,
+    })
+    alert('탈퇴 완료되었습니다.')
+    emit('close')
+  } catch (err) {
+    console.error(err)
+    alert('탈퇴에 실패했습니다.')
+  }
+}
 
 // props.userData가 바뀌면 editInfo에 반영 (모달 열 때 초기화용)
 watch(
@@ -90,7 +116,7 @@ const handlePasswordSubmit = async () => {
     await adminApi.resetPassword({
       currentPassword: passwordInfo.value.currentPassword,
       newPassword: passwordInfo.value.newPassword,
-      confirmPassword: passwordInfo.value.confirmPassword
+      confirmPassword: passwordInfo.value.confirmPassword,
     })
     alert('비밀번호가 변경되었습니다.')
     passwordInfo.value = { currentPassword: '', newPassword: '', confirmPassword: '' }
@@ -98,14 +124,6 @@ const handlePasswordSubmit = async () => {
   } catch (err) {
     console.error(err)
     alert('비밀번호 변경에 실패했습니다.')
-  }
-}
-
-// 서비스 탈퇴
-const handleWithdraw = () => {
-  if (confirm('정말 탈퇴하시겠습니까?')) {
-    alert('탈퇴 완료되었습니다.')
-    emit('close')
   }
 }
 
@@ -216,12 +234,31 @@ const formatPhoneNumber = (e) => {
         </div>
         <div class="modal-input-section">
           <label>새 비밀번호 확인</label>
-          <input  v-model="passwordInfo.confirmPassword" type="password" class="modal-input" />
+          <input v-model="passwordInfo.confirmPassword" type="password" class="modal-input" />
         </div>
 
         <div class="modal-button-container">
           <Button theme="gray" size="sm" @click="mode = 'view'">취소</Button>
           <Button size="sm" @click="handlePasswordSubmit">변경하기</Button>
+        </div>
+      </template>
+
+      <!-- 탈퇴 모드 -->
+      <template v-else-if="mode === 'withdraw'">
+        <div class="modal-header">
+          <h3>서비스 탈퇴</h3>
+        </div>
+        <div class="modal-input-section">
+          <label>비밀번호 확인</label>
+          <input v-model="withdrawInfo.password" type="password" class="modal-input" />
+        </div>
+        <div class="modal-input-section">
+          <label>탈퇴 사유 (선택)</label>
+          <input v-model="withdrawInfo.reason" type="text" class="modal-input" />
+        </div>
+        <div class="modal-button-container">
+          <Button theme="gray" size="sm" @click="mode = 'view'">취소</Button>
+          <Button size="sm" @click="handleWithdrawSubmit">탈퇴하기</Button>
         </div>
       </template>
     </div>

--- a/src/components/AccountManageModal.vue
+++ b/src/components/AccountManageModal.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, watch } from 'vue'
-import { managerInfoEdit, getManagerInfo } from '@/services/admin/admin_api'
+import adminApi from '@/services/admin/admin_api'
 
 const props = defineProps({
   open: Boolean,
@@ -58,10 +58,10 @@ const handleEditSubmit = async () => {
     }
 
     // 서버에 수정 요청
-    await managerInfoEdit(payload)
+    await adminApi.managerInfoEdit(payload)
 
     // 서버에서 최신 데이터 가져오기
-    const response = await getManagerInfo()
+    const response = await adminApi.getManagerInfo()
     Object.assign(props.userData, response.data) // props.userData 직접 업데이트
 
     // 모드 전환

--- a/src/components/AccountManageModal.vue
+++ b/src/components/AccountManageModal.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref, watch } from 'vue'
 import adminApi from '@/services/admin/admin_api'
+import { useRouter } from 'vue-router'
 
 const props = defineProps({
   open: Boolean,
@@ -9,6 +10,7 @@ const props = defineProps({
 const emit = defineEmits(['close'])
 
 const mode = ref('view') // view | edit | password | withdraw
+const router = useRouter()
 
 // 프로필 정보 수정용 임시 데이터
 const editInfo = ref({
@@ -32,6 +34,12 @@ const withdrawInfo = ref({
   reason: '',
 })
 
+// 탈퇴 모드 진입
+const enterWithdrawMode = () => {
+  withdrawInfo.value = { password: '', reason: '' }
+  mode.value = 'withdraw'
+}
+
 // 탈퇴 요청
 const handleWithdrawSubmit = async () => {
   if (!withdrawInfo.value.password) {
@@ -39,13 +47,16 @@ const handleWithdrawSubmit = async () => {
     return
   }
   try {
-    // 예시: 실제 서버 API 호출
-    await adminApi.resetPassword({
+    const payload = {
       password: withdrawInfo.value.password,
       reason: withdrawInfo.value.reason,
-    })
+    }
+    const response = await adminApi.managerInfoDelete(payload)
+
+    // 서버에서 성공 여부 확인
     alert('탈퇴 완료되었습니다.')
     emit('close')
+    router.replace('/admin/home')
   } catch (err) {
     console.error(err)
     alert('탈퇴에 실패했습니다.')
@@ -183,7 +194,7 @@ const formatPhoneNumber = (e) => {
         </div>
 
         <div class="modal-button-container">
-          <Button @click="handleWithdraw" theme="gray" size="sm">서비스 탈퇴</Button>
+          <Button @click="enterWithdrawMode" theme="gray" size="sm">서비스 탈퇴</Button>
           <Button size="sm" @click="mode = 'password'">비밀번호 변경</Button>
         </div>
       </template>
@@ -248,13 +259,13 @@ const formatPhoneNumber = (e) => {
         <div class="modal-header">
           <h3>서비스 탈퇴</h3>
         </div>
-        <div class="modal-input-section">
+        <div class="modal-input-section secession">
           <label>비밀번호 확인</label>
           <input v-model="withdrawInfo.password" type="password" class="modal-input" />
         </div>
-        <div class="modal-input-section">
-          <label>탈퇴 사유 (선택)</label>
-          <input v-model="withdrawInfo.reason" type="text" class="modal-input" />
+        <div class="modal-input-section secession">
+          <label>탈퇴 사유</label>
+          <textarea v-model="withdrawInfo.reason" type="text" class="modal-textarea"></textarea>
         </div>
         <div class="modal-button-container">
           <Button theme="gray" size="sm" @click="mode = 'view'">취소</Button>
@@ -304,11 +315,28 @@ label,
 }
 
 .modal-input,
-.modal-input-file {
+.modal-input-file,
+.modal-textarea {
   @apply bg-gray-line px-[12px] py-[8px] text-[14px] rounded-[3px];
 }
 
 .modal-input-file {
   @apply w-[193px] text-[12px] cursor-pointer;
+}
+
+.modal-textarea {
+  @apply h-[100px] w-[400px] align-top outline-none resize-none;
+}
+
+.secession {
+  @apply flex items-start gap-5;
+}
+
+.secession label {
+  @apply mt-[9px];
+}
+
+.secession input {
+  @apply w-[400px];
 }
 </style>

--- a/src/components/AccountManageModal.vue
+++ b/src/components/AccountManageModal.vue
@@ -2,6 +2,7 @@
 import { ref, watch } from 'vue'
 import adminApi from '@/services/admin/admin_api'
 import { useRouter } from 'vue-router'
+import { useAuthStore } from '@/stores/UseStore'
 
 const props = defineProps({
   open: Boolean,
@@ -11,6 +12,7 @@ const emit = defineEmits(['close'])
 
 const mode = ref('view') // view | edit | password | withdraw
 const router = useRouter()
+const authStore = useAuthStore()
 
 // 프로필 정보 수정용 임시 데이터
 const editInfo = ref({
@@ -102,7 +104,8 @@ const handleEditSubmit = async () => {
     }
 
     // 서버에 수정 요청
-    await adminApi.managerInfoEdit(payload)
+    const updatedData = await adminApi.managerInfoEdit(payload)
+    authStore.updateUser(updatedData)
 
     // 서버에서 최신 데이터 가져오기
     const response = await adminApi.getManagerInfo()

--- a/src/components/AccountManageModal.vue
+++ b/src/components/AccountManageModal.vue
@@ -10,13 +10,20 @@ const emit = defineEmits(['close'])
 
 const mode = ref('view') // view | edit | password
 
-// 수정용 임시 데이터 (수정 모드에서 사용)
+// 프로필 정보 수정용 임시 데이터
 const editInfo = ref({
   businessNumber: '',
   name: '',
   phone: '',
   logoFile: null,
   logoUrl: '', // 기존 로고 URL
+})
+
+// 비밀번호 변경용 임시 데이터
+const passwordInfo = ref({
+  currentPassword: '',
+  newPassword: '',
+  confirmPassword: ''
 })
 
 // props.userData가 바뀌면 editInfo에 반영 (모달 열 때 초기화용)
@@ -70,6 +77,27 @@ const handleEditSubmit = async () => {
   } catch (err) {
     alert('수정에 실패했습니다.')
     console.error(err)
+  }
+}
+
+// 비밀번호 변경 완료
+const handlePasswordSubmit = async () => {
+  if (passwordInfo.value.newPassword !== passwordInfo.value.confirmPassword) {
+    alert('새 비밀번호와 확인이 일치하지 않습니다.')
+    return
+  }
+  try {
+    await adminApi.resetPassword({
+      currentPassword: passwordInfo.value.currentPassword,
+      newPassword: passwordInfo.value.newPassword,
+      confirmPassword: passwordInfo.value.confirmPassword
+    })
+    alert('비밀번호가 변경되었습니다.')
+    passwordInfo.value = { currentPassword: '', newPassword: '', confirmPassword: '' }
+    mode.value = 'view'
+  } catch (err) {
+    console.error(err)
+    alert('비밀번호 변경에 실패했습니다.')
   }
 }
 
@@ -180,20 +208,20 @@ const formatPhoneNumber = (e) => {
 
         <div class="modal-input-section">
           <label>기존 비밀번호</label>
-          <input type="password" class="modal-input" />
+          <input v-model="passwordInfo.currentPassword" type="password" class="modal-input" />
         </div>
         <div class="modal-input-section">
           <label>새 비밀번호</label>
-          <input type="password" class="modal-input" />
+          <input v-model="passwordInfo.newPassword" type="password" class="modal-input" />
         </div>
         <div class="modal-input-section">
           <label>새 비밀번호 확인</label>
-          <input type="password" class="modal-input" />
+          <input  v-model="passwordInfo.confirmPassword" type="password" class="modal-input" />
         </div>
 
         <div class="modal-button-container">
           <Button theme="gray" size="sm" @click="mode = 'view'">취소</Button>
-          <Button size="sm">변경하기</Button>
+          <Button size="sm" @click="handlePasswordSubmit">변경하기</Button>
         </div>
       </template>
     </div>

--- a/src/components/AdminLayout.vue
+++ b/src/components/AdminLayout.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { onMounted, reactive, ref } from 'vue'
 import NotificationDropdown from '@/components/NotificationDropdown.vue'
+import AccountManageModal from './AccountManageModal.vue'
 import serviceApi from '@/services/admin/service_api'
 import adminApi from '@/services/admin/admin_api'
 

--- a/src/components/AdminLayout.vue
+++ b/src/components/AdminLayout.vue
@@ -2,13 +2,13 @@
 import { ref } from 'vue'
 import AccountManageModal from './AccountManageModal.vue'
 import NotificationDropdown from '@/components/NotificationDropdown.vue'
-import { getManagerInfo } from '@/services/admin/admin_api'
+import adminApi from '@/services/admin/admin_api'
 
 const isModalOpen = ref(false)
 const userData = ref(null)  
 async function openModal() {
   try {
-    const response = await getManagerInfo()
+    const response = await adminApi.getManagerInfo()
     userData.value = response.data 
     isModalOpen.value = true
   } catch (err) {

--- a/src/components/AdminLayout.vue
+++ b/src/components/AdminLayout.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { onMounted, reactive, ref } from 'vue'
+import { useAuthStore } from '@/stores/UseStore'
 import NotificationDropdown from '@/components/NotificationDropdown.vue'
 import AccountManageModal from './AccountManageModal.vue'
 import serviceApi from '@/services/admin/service_api'
@@ -8,6 +9,7 @@ import adminApi from '@/services/admin/admin_api'
 
 const isModalOpen = ref(false)
 const userData = ref(null)  
+const authStore = useAuthStore()
 
 async function openModal() {
   try {
@@ -162,7 +164,7 @@ onMounted(() => {
             src="/public/assets/images/admin_logo.png"
             alt="기업 로고 이미지"
           />
-          <span @click="openModal">김아영 관리자님</span>
+          <span @click="openModal">{{ authStore.user?.name }} 관리자님</span>
           <button @click.stop="notiToggleDropdown" class="super-notify-btn">
             <img src="/assets/icons/ic-new-notify.png" alt="알림 아이콘" class="notify-icon" />
           </button>

--- a/src/components/AdminLayout.vue
+++ b/src/components/AdminLayout.vue
@@ -1,6 +1,20 @@
 <script setup>
 import { ref } from 'vue'
+import AccountManageModal from './AccountManageModal.vue'
 import NotificationDropdown from '@/components/NotificationDropdown.vue'
+import { getManagerInfo } from '@/services/admin/admin_api'
+
+const isModalOpen = ref(false)
+const userData = ref(null)  
+async function openModal() {
+  try {
+    const response = await getManagerInfo()
+    userData.value = response.data 
+    isModalOpen.value = true
+  } catch (err) {
+    console.error('프로필 조회 실패', err)
+  }
+}
 
 // 예시 서비스 그룹 목록입니다.
 const services = ref([
@@ -116,8 +130,12 @@ const notiToggleDropdown = () => {
     <div class="content-body">
       <div class="content-top">
         <div class="admin-badge">
-          <img src="/public/assets/images/admin_logo.png" alt="기업 로고 이미지" />
-          <span>김아영 관리자님</span>
+          <img
+            @click="openModal"
+            src="/public/assets/images/admin_logo.png"
+            alt="기업 로고 이미지"
+          />
+          <span @click="openModal">김아영 관리자님</span>
           <button @click.stop="notiToggleDropdown" class="super-notify-btn">
             <img src="/assets/icons/ic-new-notify.png" alt="알림 아이콘" class="notify-icon" />
           </button>
@@ -135,6 +153,7 @@ const notiToggleDropdown = () => {
       </div>
     </div>
   </div>
+  <AccountManageModal :open="isModalOpen" :userData="userData" @close="isModalOpen = false" />
 </template>
 
 <style scoped>

--- a/src/services/admin/admin_api.js
+++ b/src/services/admin/admin_api.js
@@ -102,6 +102,19 @@ const managerInfoEdit = async (managerInfo) => {
   }
 }
 
+/**
+ * 탈퇴하기
+ */
+const managerInfoDelete = async (managerInfo) => {
+  try {
+    const response = await axiosInstance.delete('/api/admins/me', managerInfo)
+    return response.data
+  } catch (error) {
+    console.error('프로필 수정 실패', error)
+    throw error
+  }
+}
+
 
 export default {
   signUpAdmin,

--- a/src/services/admin/admin_api.js
+++ b/src/services/admin/admin_api.js
@@ -70,6 +70,33 @@ const resetPassword = async (passwordData) => {
   return await axiosInstance.patch('/api/admins/password/reset', passwordData)
 }
 
+/**
+ * 내 정보 조회
+ */
+export const getManagerInfo = async (email, companyId) => {
+  try {
+    const response = await axiosInstance.get('/api/admins/me')
+    return response.data
+  } catch (error) {
+    console.error('프로필 조회 실패', error)
+    throw error
+  }
+}
+
+/**
+ * 내 정보 수정
+ */
+export const managerInfoEdit = async (managerInfo) => {
+  try {
+    const response = await axiosInstance.patch('/api/admins/me', managerInfo)
+    return response.data
+  } catch (error) {
+    console.error('프로필 수정 실패', error)
+    throw error
+  }
+}
+
+
 export default {
   signUpAdmin,
   checkBusinessNumber,
@@ -77,5 +104,5 @@ export default {
   checkEmail,
   getSignUpStatus,
   login,
-  resetPassword
+  resetPassword,
 }

--- a/src/services/admin/admin_api.js
+++ b/src/services/admin/admin_api.js
@@ -68,7 +68,7 @@ const login = async (loginData) => {
  */
 const resetPassword = async (payload) => {
   try {
-    const response = await axiosInstance.post('/api/admins/password', payload)
+    const response = await axiosInstance.patch('/api/admins/password/reset', payload)
     return response.data
   } catch (error) {
     console.error('비밀번호 변경 실패', error)

--- a/src/services/admin/admin_api.js
+++ b/src/services/admin/admin_api.js
@@ -105,12 +105,15 @@ const managerInfoEdit = async (managerInfo) => {
 /**
  * 탈퇴하기
  */
-const managerInfoDelete = async (managerInfo) => {
+const managerInfoDelete = async (payload) => {
   try {
-    const response = await axiosInstance.delete('/api/admins/me', managerInfo)
+    const response = await axiosInstance.delete('/api/admins/me', {
+      data: payload,
+    })
+    console.log('managerInfoDelete response', response.data) 
     return response.data
   } catch (error) {
-    console.error('프로필 수정 실패', error)
+    console.error('탈퇴 실패', error)
     throw error
   }
 }
@@ -126,4 +129,5 @@ export default {
   resetPassword,
   getManagerInfo,
   managerInfoEdit,
+  managerInfoDelete,
 }

--- a/src/services/admin/admin_api.js
+++ b/src/services/admin/admin_api.js
@@ -66,14 +66,20 @@ const login = async (loginData) => {
 /**
  * 비밀번호 재설정
  */
-const resetPassword = async (passwordData) => {
-  return await axiosInstance.patch('/api/admins/password/reset', passwordData)
+const resetPassword = async (payload) => {
+  try {
+    const response = await axiosInstance.post('/api/admins/password', payload)
+    return response.data
+  } catch (error) {
+    console.error('비밀번호 변경 실패', error)
+    throw error
+  }
 }
 
 /**
  * 내 정보 조회
  */
-export const getManagerInfo = async (email, companyId) => {
+const getManagerInfo = async (email, companyId) => {
   try {
     const response = await axiosInstance.get('/api/admins/me')
     return response.data
@@ -86,7 +92,7 @@ export const getManagerInfo = async (email, companyId) => {
 /**
  * 내 정보 수정
  */
-export const managerInfoEdit = async (managerInfo) => {
+const managerInfoEdit = async (managerInfo) => {
   try {
     const response = await axiosInstance.patch('/api/admins/me', managerInfo)
     return response.data
@@ -105,4 +111,6 @@ export default {
   getSignUpStatus,
   login,
   resetPassword,
+  getManagerInfo,
+  managerInfoEdit,
 }

--- a/src/stores/UseStore.js
+++ b/src/stores/UseStore.js
@@ -3,7 +3,7 @@ import { ref } from 'vue'
 
 export const useAuthStore = defineStore('auth', () => {
   // ===== 상태 =====
-  
+
   const isLoggedIn = ref(false)
   const user = ref(null)
   const role = ref(null)
@@ -11,7 +11,7 @@ export const useAuthStore = defineStore('auth', () => {
   const companySlug = ref(null)
 
   // ===== 로그인 액션 =====
-  
+
   /**
    * 로그인 처리
    * - 사용자 정보 저장 (토큰은 쿠키로 자동 관리됨)
@@ -27,25 +27,49 @@ export const useAuthStore = defineStore('auth', () => {
     localStorage.setItem('isLoggedIn', 'true')
     localStorage.setItem('user', JSON.stringify(userData))
     localStorage.setItem('role', userRole)
-    
+
     if (userCompanyId) {
       localStorage.setItem('companyId', userCompanyId.toString())
     }
-    
+
     if (userCompanySlug) {
       localStorage.setItem('companySlug', userCompanySlug)
     }
 
-    console.log('로그인 완료:', { 
-      isLoggedIn: isLoggedIn.value, 
+    console.log('로그인 완료:', {
+      isLoggedIn: isLoggedIn.value,
       role: role.value,
       companyId: companyId.value,
-      companySlug: companySlug.value 
+      companySlug: companySlug.value,
     })
   }
 
+  // ===== 정보 수정 액션 =====
+  const updateUser = (updatedData) => {
+    if (!updatedData || !updatedData.data) return
+
+    const data = updatedData.data
+
+    if (!user.value) {
+      user.value = {}
+    }
+
+    // 필요한 값만 업데이트
+    user.value.userId = data.id ?? user.value.userId
+    user.value.name = data.name ?? user.value.name
+    user.value.email = data.email ?? user.value.email
+
+    // localStorage에도 저장
+    const storedUser = JSON.parse(localStorage.getItem('user') || '{}')
+    storedUser.userId = user.value.userId
+    storedUser.name = user.value.name
+    storedUser.email = user.value.email
+    localStorage.setItem('user', JSON.stringify(storedUser))
+  }
+
+
   // ===== 로그아웃 액션 =====
-  
+
   /**
    * 로그아웃 처리
    * - 모든 상태 초기화
@@ -69,7 +93,7 @@ export const useAuthStore = defineStore('auth', () => {
   }
 
   // ===== 인증 상태 복원 =====
-  
+
   /**
    * 인증 상태 복원 (페이지 새로고침 시)
    */
@@ -87,11 +111,11 @@ export const useAuthStore = defineStore('auth', () => {
       companyId.value = savedCompanyId ? parseInt(savedCompanyId) : null
       companySlug.value = savedCompanySlug || null
 
-      console.log('♻️ 인증 상태 복원:', { 
-        isLoggedIn: isLoggedIn.value, 
+      console.log('♻️ 인증 상태 복원:', {
+        isLoggedIn: isLoggedIn.value,
         role: role.value,
         companyId: companyId.value,
-        companySlug: companySlug.value 
+        companySlug: companySlug.value,
       })
     } else {
       console.log('저장된 인증 상태 없음')
@@ -112,7 +136,7 @@ export const useAuthStore = defineStore('auth', () => {
     if (companySlug.value && companySlug.value !== currentSlug) {
       console.warn('다른 회사 페이지 접근 감지 - 로그아웃 처리:', {
         saved: companySlug.value,
-        current: currentSlug
+        current: currentSlug,
       })
       logout()
       return false
@@ -130,6 +154,7 @@ export const useAuthStore = defineStore('auth', () => {
     login,
     logout,
     checkAuth,
-    validateCompanyContext  
+    validateCompanyContext,
+    updateUser,
   }
 })


### PR DESCRIPTION
## #️⃣ Issue Number

- #143 

<br />

## 📝 요약(Summary)

관리자 정보 조회/수정, 비밀번호 수정, 회원 탈퇴 기능 백-프론트 연결했습니다.

### 1. **관리자 정보 조회**
   오른쪽 상단에 있는 기업로고나 관리자 이름을 클릭하면 아래와 같이 관리자 정보가 담긴 모달이 뜹니다.

   <img width="1891" height="855" alt="image" src="https://github.com/user-attachments/assets/9e2bd730-1de8-4f49-a296-a43d0af7914b" />

### 2. **관리자 정보 수정**
   모달 오른쪽 상단에 있는 `수정` 글자 클릭 시 아래와 같이 수정 모달로 바뀝니다.

   <img width="803" height="646" alt="image" src="https://github.com/user-attachments/assets/edc5e616-ed0c-405b-831e-929226a45b32" />

### 3. **관리자 비밀번호 수정**

   비밀번호 수정 버튼을 클릭하면 비밀번호 수정 모달로 바뀝니다.

   <img width="867" height="665" alt="image" src="https://github.com/user-attachments/assets/2365593e-9964-4a3c-bf39-6cd375dc5a7d" />

### 4. **회원 탈퇴**

   탈퇴 클릭 시 탈퇴가 진행되고 `admin/home`로 이동합니다.

### 5. **관리자 이름 수정 시 프로필 이름도 변경**

   관리자 수정 모달에서 이름을 수정하면 아래의 프로필에서의 이름도 수정됩니다.

   <img width="380" height="94" alt="image" src="https://github.com/user-attachments/assets/8f7396bc-6513-4535-b83f-ba2bc0f019bc" />

<br />

## 📸스크린샷

길이가 길어서 gif 변환 못 했으용..

https://github.com/user-attachments/assets/ad64d3ad-81fa-4ab5-b83f-fcb686a206b1

<br />

## 💬 공유사항

이미지 처리 기능이 생기면 로고 이미지 수정 로직도 구현하겠습니다!

<br />