### PR TITLE
[Fix] 서비스 수정 페이지

### DIFF
--- a/src/components/AdminLayout.vue
+++ b/src/components/AdminLayout.vue
@@ -13,23 +13,14 @@ const authStore = useAuthStore()
 async function openModal() {
   try {
     const response = await adminApi.getManagerInfo()
-    console.log('🔍 전체 응답:', response)
-    console.log('🔍 response.data:', response.data)
 
-    // BaseResponse 구조: { code, message, data: {...}, isSuccess }
-    // response.data가 이미 BaseResponse이므로 response.data.data가 실제 데이터
     if (response.data && response.data.data) {
       userData.value = response.data.data
     } else {
-      // 만약 response.data가 직접 데이터라면
       userData.value = response.data
     }
-
-    console.log('🔍 최종 userData:', userData.value)
     isModalOpen.value = true
   } catch (err) {
-    console.error('❌ 프로필 조회 실패:', err)
-    console.error('❌ 에러 응답:', err.response)
     alert('프로필 조회에 실패했습니다.')
   }
 }

--- a/src/components/CustomFieldAdd.vue
+++ b/src/components/CustomFieldAdd.vue
@@ -58,9 +58,12 @@ const removeOption = (index) => {
 const addFieldFromModal = () => {
   if (!modalFieldName.value) return alert('항목명을 입력해주세요.')
 
+  const typeItem = types.value.find(t => t.value === modalFieldType.value)
+
   const payload = {
     fieldName: modalFieldName.value,
-    dataType: modalFieldType.value,
+    dataType: modalFieldType.value,      // 서버 전송용
+    dataTypeLabel: typeItem?.label || '', // 화면 표시용
     description: modalFieldDescription.value,
   }
 
@@ -87,8 +90,7 @@ const addFieldFromModal = () => {
     />
     <Input
       class="input-style !w-[150px]"
-      :options="types"
-      v-model="field.dataType"
+      v-model="field.dataTypeLabel"
       placeholder="데이터 타입"
       :disabled="true"
     />
@@ -265,11 +267,11 @@ textarea {
 }
 
 .option-list {
-  @apply flex flex-col gap-1
+  @apply flex flex-col gap-1;
 }
 
 ::-webkit-scrollbar-thumb {
-  border-radius: 6px;          /* 모서리 둥글게 */
-  border: 3px solid #f0f0f0;  /* 주변 여백 색 */
+  border-radius: 6px; /* 모서리 둥글게 */
+  border: 3px solid #f0f0f0; /* 주변 여백 색 */
 }
 </style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -7,6 +7,7 @@ const router = createRouter({
     ////////////////////////////////////////////////////////////////////////////////////////////////////////
     // 고객 관련 라우터
     ////////////////////////////////////////////////////////////////////////////////////////////////////////
+
     {
       path: '/c/:companySlug/',
       name: 'UserLogin',
@@ -146,6 +147,11 @@ const router = createRouter({
       path: '/admin/service-create/:serviceGroupId',
       name: 'ServiceCreate',
       component: () => import('@/views/admin/ServiceCreate.vue'),
+    },
+    {
+      path: '/admin/service-edit/:serviceGroupId',
+      name: 'ServiceEdit',
+      component: () => import('@/views/admin/ServiceEdit.vue'),
     },
     {
       path: '/admin/service-management/:serviceGroupId',

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -149,7 +149,7 @@ const router = createRouter({
       component: () => import('@/views/admin/ServiceCreate.vue'),
     },
     {
-      path: '/admin/service-edit/:serviceGroupId',
+      path: '/admin/service-edit/:serviceId',
       name: 'ServiceEdit',
       component: () => import('@/views/admin/ServiceEdit.vue'),
     },

--- a/src/services/admin/service_api.js
+++ b/src/services/admin/service_api.js
@@ -81,6 +81,10 @@ const getServiceList = async (serviceGroupId) => {
   return await axiosInstance.get(`api/resource/group/${serviceGroupId}`)
 }
 
+const getResourceCustomFieldAndValue = async (resourceId) => {
+  return await axiosInstance.get(`/api/custom-field/value/resource/${resourceId}?type=RESOURCE`)
+}
+
 export default {
   createServiceGroup,
   getServiceGroupPresignedURL,
@@ -92,4 +96,5 @@ export default {
   createService,
   getServiceGroupFieldInfo,
   getServiceList,
+  getResourceCustomFieldAndValue,
 }

--- a/src/services/admin/service_api.js
+++ b/src/services/admin/service_api.js
@@ -77,6 +77,10 @@ const createService = async (formdata) => {
   return await axiosInstance.post(`api/resource`, formdata)
 }
 
+const getServiceList = async (serviceGroupId) => {
+  return await axiosInstance.get(`api/resource/group/${serviceGroupId}`)
+}
+
 export default {
   createServiceGroup,
   getServiceGroupPresignedURL,
@@ -87,4 +91,5 @@ export default {
   deleteServiceGroup,
   createService,
   getServiceGroupFieldInfo,
+  getServiceList,
 }

--- a/src/views/admin/ServiceEdit.vue
+++ b/src/views/admin/ServiceEdit.vue
@@ -1,0 +1,508 @@
+<script setup>
+import { ref, watch } from 'vue'
+import AdminLayout from '@/components/AdminLayout.vue'
+import Breadcrumb from '@/components/Breadcrumb.vue'
+import TimeSlotModal from '@/components/TimeSlotModal.vue'
+import { useRoute, useRouter } from 'vue-router'
+import serviceApi from '@/services/admin/service_api'
+import ExceptionModal from '@/components/ExceptionModal.vue'
+
+const route = useRoute()
+const router = useRouter()
+const serviceGroupId = route.params.serviceGroupId
+const serviceGroupName = decodeURIComponent(route.query.serviceGroupName || '')
+
+const thumbnail = ref('')
+
+const category = ref([
+  { label: '예약형', value: 'RESERVATION' },
+  { label: '좌석형', value: 'SEAT' },
+  { label: '신청형', value: 'EVENT' },
+])
+
+// 커스텀 필드 데이터 더미
+const customFields = ref([
+  {
+    fieldName: '최대 인원',
+    description: '예약 가능한 최대 인원 수를 입력해주세요.',
+    dataType: 'NUMBER',
+  },
+  { fieldName: '서비스 이름', description: '서비스의 이름을 입력해주세요.', dataType: 'TEXT' },
+  { fieldName: '시작일', description: '서비스가 시작되는 날짜를 선택해주세요.', dataType: 'DATE' },
+  { fieldName: '운영 시간', description: '서비스 운영 시간을 입력해주세요.', dataType: 'TIME' },
+  {
+    fieldName: '예약 유형',
+    description: '예약형, 좌석형 중 하나를 선택해주세요.',
+    dataType: 'RADIO',
+    options: ['예약형', '좌석형'],
+  },
+  {
+    fieldName: '추가 옵션',
+    description: '선택 가능한 추가 옵션을 모두 선택해주세요.',
+    dataType: 'CHECKBOX',
+    options: ['옵션1', '옵션2'],
+  },
+  {
+    fieldName: '온라인 결제 가능',
+    description: '서비스에 온라인 결제를 허용할지 여부를 선택해주세요.',
+    dataType: 'BOOLEAN',
+  },
+])
+
+const name = ref('')
+const description = ref('')
+const capacity = ref(null)
+const startDate = ref('')
+const endDate = ref('')
+const startTime = ref('')
+const endTime = ref('')
+const timeInterval = ref(60)
+const row = ref(null)
+const col = ref(null)
+const exceptions = ref([]) // 예외 일정 배열
+
+// 두 모달을 ref로 연결
+const timeSlotRef = ref(null)
+const exceptionRef = ref(null)
+
+watch(timeInterval, (newVal, oldVal) => {
+  if (newVal !== oldVal) {
+    // 값이 바뀌면 바로 초기화
+    timeSlotRef.value?.resetAll?.()
+    exceptionRef.value?.resetAll?.()
+    exceptions.value = []
+  }
+})
+
+// 생성 요청
+const createService = async () => {
+  try {
+    const formData = {
+      name: name.value,
+      description: description.value,
+      resourceGroupId: Number(serviceGroupId),
+      startDate: startDate.value || null,
+      endDate: endDate.value || null,
+      startTime: startTime.value || null,
+      endTime: endTime.value || null,
+      timeInterval: timeInterval.value,
+      capacity: capacity.value ? Number(capacity.value) : null,
+      row: row.value ? Number(row.value) : null,
+      col: col.value ? Number(col.value) : null,
+    }
+
+    const response = await serviceApi.createService(formData)
+    alert('서비스가 성공적으로 생성되었습니다!')
+    console.log('✅ 등록 완료:', response.data)
+    router.push(`/admin/service-management/${serviceGroupId}?serviceGroupName=${serviceGroupName}`)
+  } catch (error) {
+    console.error('❌ 서비스 생성 실패:', error)
+    alert('서비스 생성 중 오류가 발생했습니다.')
+  }
+}
+
+// 브레드크럼 항목
+const breadcrumbItems = [{ label: 'Service Groups', path: '#!' }, { label: serviceGroupName }]
+
+// 입력값 초기화
+const resetValues = () => {
+  name.value = ''
+  description.value = ''
+  capacity.value = null
+  startDate.value = ''
+  endDate.value = ''
+  startTime.value = ''
+  endTime.value = ref('')
+  timeInterval.value = ref(60)
+  row.value = null
+  col.value = null
+}
+
+// ---서비스 이미지 업로드---
+const onFileChange = async (event) => {
+  const file = event.target.files[0]
+  if (!file) return
+
+  try {
+    // 1. FormData 생성 및 백엔드에서 presigned URL 요청
+    const formData = new FormData()
+    formData.append('file', file)
+    formData.append('imageType', 'serviceGroup')
+
+    const presignedUrl = await serviceApi.getServiceGroupPresignedURL(formData)
+    if (!presignedUrl) throw new Error('Presigned URL을 가져오지 못했습니다.')
+
+    console.log('Presigned URL:', presignedUrl)
+
+    // 2. S3에 이미지 업로드
+    await serviceApi.uploadImage(presignedUrl, file)
+
+    // 3. CloudFront URL로 변환
+    const cloudFrontDomain = 'https://d2h9e9y86awp4t.cloudfront.net'
+    const s3Path = presignedUrl.split('.com')[1].split('?')[0] // 쿼리 제거
+    thumbnail.value = cloudFrontDomain + s3Path
+
+    console.log('CloudFront URL:', thumbnail.value)
+
+  } catch (error) {
+    console.error('이미지 업로드 과정에서 오류 발생:', error)
+    alert('이미지 업로드 중 오류가 발생했습니다.')
+  }
+}
+</script>
+
+<template>
+  <AdminLayout>
+    <!-- 페이지 헤더 -->
+    <div class="components-page-title">
+      <div class="head">
+        <Breadcrumb :items="breadcrumbItems" />
+        <span>서비스 생성</span>
+      </div>
+    </div>
+
+    <!-- 서비스 정보 입력 폼 -->
+    <!-- 서비스 이미지 -->
+    <section>
+      <div class="form-label-container">
+        <div>커버 이미지</div>
+        <p>고객들이 어떤 서비스인지 쉽게 알 수 있도록 알맞은 이미지를 업로드 해주세요.</p>
+      </div>
+      <div id="service-group-image-upload">
+        <label for="file-upload" class="file-upload-label">
+          <template v-if="thumbnail">
+            <img :src="thumbnail" class="service-group-thumbnail" alt="미리보기" />
+          </template>
+          <template v-else>
+            이미지 업로드
+          </template>
+        </label>
+        <input id="file-upload" type="file" class="file-upload-input"  @change="onFileChange"/>
+      </div>
+    </section>
+
+    <!-- 서비스 이름 -->
+    <section>
+      <div class="form-label-container">
+        <div>서비스 이름 <span>*</span></div>
+        <p>어떤 서비스인가요? ( ex. 회의실 A, 클라이밍 동아리 등등 )</p>
+      </div>
+      <Input
+        class="text-input"
+        v-model="name"
+        type="text"
+        placeholder="서비스 이름을 작성해주세요."
+      />
+    </section>
+
+    <!-- 서비스 설명 -->
+    <section>
+      <div class="form-label-container">
+        <div>서비스 설명 <span>*</span></div>
+      </div>
+      <textarea placeholder="서비스 설명을 작성해주세요."></textarea>
+    </section>
+
+    <!-- 수용 인원 -->
+    <section>
+      <div class="form-label-container">
+        <div>수용 인원 <span>*</span></div>
+        <p>해당 서비스의 최대 수용 인원 수를 알려주세요.</p>
+      </div>
+      <Input
+        class="text-input"
+        v-model="capacity"
+        type="number"
+        placeholder="숫자로만 작성해주세요."
+      />
+    </section>
+
+    <!-- 행 -->
+    <section>
+      <div class="form-label-container">
+        <div>행 <span>*</span></div>
+        <p>좌석의 행 수를 입력해주세요.</p>
+      </div>
+      <Input class="text-input" v-model="row" type="number" placeholder="숫자로만 작성해주세요." />
+    </section>
+
+    <!-- 열 -->
+    <section>
+      <div class="form-label-container">
+        <div>열 <span>*</span></div>
+        <p>좌석의 열 수를 입력해주세요.</p>
+      </div>
+      <Input class="text-input" v-model="col" type="number" placeholder="숫자로만 작성해주세요." />
+    </section>
+
+    <!-- 서비스 정보 -->
+    <section class="mt-[40px]">
+      <div class="form-label-container">
+        <div>서비스 정보 <span>*</span></div>
+      </div>
+
+      <!-- 예약/신청 기간 -->
+      <div class="service-info-section">
+        <div class="service-info-form-item-label-container !mt-[5px]">
+          <span>예약/신청 기간</span>
+          <p>해당 서비스의 예약/신청이 가능한 기간을 입력해 주세요.</p>
+        </div>
+
+        <div class="service-info-form-inputs">
+          <Input class="text-input" v-model="startDate" type="date" placeholder="시작 날짜" />
+          <span>~</span>
+          <Input class="text-input" v-model="endDate" type="date" placeholder="종료 날짜" />
+        </div>
+      </div>
+
+      <!-- 시간 간격 선택 -->
+      <div class="service-info-section">
+        <div class="service-info-form-item-label-container">
+          <span>시간 간격 선택</span>
+        </div>
+
+        <div class="service-info-form-radio">
+          <Input
+            type="radio"
+            label="1시간"
+            :value="60"
+            name="timeInterval"
+            v-model="timeInterval"
+            class="text-input"
+          />
+          <Input
+            type="radio"
+            label="30분"
+            :value="30"
+            name="timeInterval"
+            v-model="timeInterval"
+            class="text-input"
+          />
+        </div>
+      </div>
+
+      <!-- 서비스 이용 시간  -->
+      <div class="service-info-section">
+        <div class="service-info-form-item-label-container">
+          <span>정기 이용 시간 (매주 반복)</span>
+          <p>
+            매주 반복되는 기본 운영 시간을 등록하세요. 휴게 시간을 포함한 전체 시간을 입력하신 뒤
+            휴게 시간을 제거하시면 됩니다.
+          </p>
+        </div>
+
+        <div class="service-info-form-inputs">
+          <TimeSlotModal ref="timeSlotRef" :interval="timeInterval" />
+        </div>
+      </div>
+
+      <!-- 제외 시간  -->
+      <div class="service-info-section mt-[40px]">
+        <div class="service-info-form-item-label-container">
+          <span>예외 일정</span>
+          <p>특정 날짜에만 적용되는 일정이 있거나 휴무나 점검 시간 등을 입력해 주세요.</p>
+        </div>
+
+        <div class="service-info-form-inputs">
+          <ExceptionModal
+            ref="exceptionRef"
+            :interval="timeInterval"
+            v-model:modelValue="exceptions"
+          />
+        </div>
+      </div>
+
+      <!-- 커스텀 필드 -->
+      <div class="service-info-section mt-[40px]">
+        <div v-for="(field, index) in customFields" :key="index" class="mb-[20px]">
+          <div class="service-info-form-item-label-container">
+            <span>{{ field.fieldName }}</span>
+            <p>{{ field.description }}</p>
+          </div>
+          <div class="service-info-form-inputs">
+            <!-- NUMBER -->
+            <Input
+              v-if="field.dataType === 'NUMBER'"
+              type="number"
+              class="text-input"
+              placeholder="숫자를 입력해주세요"
+            />
+
+            <!-- TEXT -->
+            <Input
+              v-else-if="field.dataType === 'TEXT'"
+              type="text"
+              class="text-input"
+              placeholder="문자를 입력해주세요"
+            />
+
+            <!-- DATE -->
+            <Input v-else-if="field.dataType === 'DATE'" type="date" class="text-input" />
+
+            <!-- TIME -->
+            <Input v-else-if="field.dataType === 'TIME'" type="time" class="text-input" />
+
+            <!-- RADIO -->
+            <div v-else-if="field.dataType === 'RADIO'" class="option-list">
+              <label v-for="(option, idx) in field.options" :key="idx">
+                <Input type="radio" :name="`radio-${index}`" :value="option" :label="`${option}`" class="text-input"/>
+              </label>
+            </div>
+
+            <!-- CHECKBOX -->
+            <div v-else-if="field.dataType === 'CHECKBOX'" class="option-list">
+              <label v-for="(option, idx) in field.options" :key="idx">
+                <Input type="checkbox" :value="option" :label="`${option}`" class="text-input"/>
+              </label>
+            </div>
+
+            <!-- BOOLEAN -->
+            <label v-else-if="field.dataType === 'BOOLEAN'"> <Input type="checkbox" label="허용" class="text-input"/></label>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- 버튼 컨테이너 -->
+    <div class="button-container">
+      <Button theme="gray" @click="resetValues">초기화</Button>
+      <Button @click="createService">생성하기</Button>
+    </div>
+  </AdminLayout>
+</template>
+
+<style scoped>
+.form-label-container:first-child {
+  @apply mt-[20px];
+}
+
+.form-label-container {
+  @apply flex gap-3 items-center mt-[35px] mb-[6px];
+}
+
+.form-label-container img {
+  @apply w-[14px] h-[14px] cursor-pointer;
+}
+
+#service-group-image-upload {
+  @apply rounded-[3px] bg-[#D9D9D9] w-[507px] h-[264px] flex items-center justify-center cursor-pointer;
+}
+
+.service-group-thumbnail {
+  @apply max-w-full max-h-full;
+}
+
+.file-upload-input {
+  @apply hidden;
+}
+
+.file-upload-label {
+  @apply flex w-full h-full flex items-center justify-center cursor-pointer text-[15px] text-gray-dark;
+}
+
+.form-label-container > div {
+  @apply flex gap-1 text-[15px];
+}
+
+.form-label-container span {
+  @apply text-[#E23148];
+}
+
+.form-label-container p {
+  @apply text-[12px] text-[#929292] flex items-center gap-2;
+}
+
+.form-label-container img {
+  @apply w-[14px] h-[14px] cursor-pointer;
+}
+
+#service-group-image-upload {
+  @apply rounded-[3px] bg-[#D9D9D9] w-[507px] h-[264px] flex items-center justify-center cursor-pointer;
+}
+
+.file-upload-input {
+  @apply hidden;
+}
+
+.file-upload-label {
+  @apply w-full h-full flex items-center justify-center cursor-pointer text-[15px] text-gray-dark;
+}
+
+.text-input {
+  @apply w-[600px] text-[14px];
+}
+
+textarea {
+  @apply resize-none rounded placeholder-gray-400 hover:placeholder-gray-600 outline-none border-b-2 transition-all duration-200 focus:border-primary disabled:bg-gray-100 disabled:cursor-not-allowed text-[14px] px-2.5 py-2.5 w-[1000px] h-[125px];
+}
+
+.radio-button-container {
+  @apply mt-[18px] flex flex-col gap-2;
+}
+
+.radio-style {
+  @apply text-[14px] w-fit;
+}
+
+.dropdown-style {
+  @apply text-[14px];
+}
+
+.button-container {
+  @apply mt-[50px] flex gap-2;
+}
+
+.button-container button {
+  @apply text-[14px] px-[22px];
+}
+
+.resource-create-question-container {
+  @apply relative inline-block;
+}
+
+.question-icon {
+  @apply cursor-pointer;
+}
+
+.category-description-box {
+  display: none;
+  @apply absolute top-full left-0 bg-white border border-gray-300 
+  rounded-[3px] p-3 w-[380px] shadow-md text-xs leading-relaxed z-10;
+}
+
+.resource-create-question-container:hover .category-description-box {
+  display: block;
+}
+
+.service-info-form-item-label-container {
+  @apply flex gap-3 items-center mt-[20px] mb-[6px];
+}
+
+.service-info-form-item-label-container span {
+  @apply text-[14px];
+}
+
+.service-info-form-item-label-container p {
+  @apply text-[12px] text-[#929292];
+}
+
+.service-info-form-inputs {
+  @apply flex gap-2 items-center max-w-[400px];
+}
+
+.service-info-section {
+  @apply ml-[4px];
+}
+
+.service-info-form-radio {
+  @apply flex flex-col gap-3 pt-[8px] pb-[15px];
+}
+
+.exception-modal-open-button {
+  @apply bg-blue-600 text-white w-[40px] h-[40px] rounded text-[30px] items-center flex justify-center;
+}
+
+.option-list {
+  @apply flex flex-col gap-2
+}
+</style>

--- a/src/views/admin/ServiceEdit.vue
+++ b/src/views/admin/ServiceEdit.vue
@@ -9,10 +9,12 @@ import ExceptionModal from '@/components/ExceptionModal.vue'
 
 const route = useRoute()
 const router = useRouter()
-const serviceGroupId = route.params.serviceGroupId
+const serviceId = route.params.serviceId
+const serviceGroupId = route.query.serviceGroupId
 const serviceGroupName = decodeURIComponent(route.query.serviceGroupName || '')
-
 const thumbnail = ref('')
+
+console.log(serviceId, serviceGroupId, serviceGroupName)
 
 const category = ref([
   { label: '예약형', value: 'RESERVATION' },
@@ -74,35 +76,8 @@ watch(timeInterval, (newVal, oldVal) => {
   }
 })
 
-// 생성 요청
-const createService = async () => {
-  try {
-    const formData = {
-      name: name.value,
-      description: description.value,
-      resourceGroupId: Number(serviceGroupId),
-      startDate: startDate.value || null,
-      endDate: endDate.value || null,
-      startTime: startTime.value || null,
-      endTime: endTime.value || null,
-      timeInterval: timeInterval.value,
-      capacity: capacity.value ? Number(capacity.value) : null,
-      row: row.value ? Number(row.value) : null,
-      col: col.value ? Number(col.value) : null,
-    }
-
-    const response = await serviceApi.createService(formData)
-    alert('서비스가 성공적으로 생성되었습니다!')
-    console.log('✅ 등록 완료:', response.data)
-    router.push(`/admin/service-management/${serviceGroupId}?serviceGroupName=${serviceGroupName}`)
-  } catch (error) {
-    console.error('❌ 서비스 생성 실패:', error)
-    alert('서비스 생성 중 오류가 발생했습니다.')
-  }
-}
-
 // 브레드크럼 항목
-const breadcrumbItems = [{ label: 'Service Groups', path: '#!' }, { label: serviceGroupName }]
+const breadcrumbItems = [{ label: 'Service Groups', path: '#!' }, { label: serviceGroupName, path: `/admin/service-management/${serviceGroupId}` }, { label: '서비스 수정', path: '' }]
 
 // 입력값 초기화
 const resetValues = () => {

--- a/src/views/admin/ServiceGroupCreate.vue
+++ b/src/views/admin/ServiceGroupCreate.vue
@@ -166,8 +166,8 @@ const createServiceGroup = async () => {
         </p>
       </div>
       <div class="radio-button-container">
-        <Input v-model="isAlwaysAvailable" class="radio-style" type="radio" label="예" value="true" />
-        <Input v-model="isAlwaysAvailable" class="radio-style" type="radio" label="아니오" value="false" />
+        <Input v-model="isAlwaysAvailable" class="radio-style" type="radio" label="예" :value="true" />
+<Input v-model="isAlwaysAvailable" class="radio-style" type="radio" label="아니오" :value="false" />
       </div>
     </section>
 

--- a/src/views/admin/ServiceGroupCreate.vue
+++ b/src/views/admin/ServiceGroupCreate.vue
@@ -105,7 +105,7 @@ const createServiceGroup = async () => {
     const response = await serviceApi.createServiceGroup(formData)
     console.log('✅ 서비스 그룹 생성 성공:', response.data)
     alert('서비스 그룹이 성공적으로 생성되었습니다!')
-    router.push({ name: 'ServiceGroupManagation' })
+    router.push({ name: 'ServiceGroupManagement' })
   } catch (error) {
     console.error('❌ 서비스 그룹 생성 실패:', error)
     alert('서비스 그룹 생성 중 오류가 발생했습니다.')

--- a/src/views/admin/ServiceGroupManagement.vue
+++ b/src/views/admin/ServiceGroupManagement.vue
@@ -19,6 +19,10 @@ const getServiceGroups = async () => {
 }
 
 const deleteServiceGroup = async (serviceGroupId) => {
+  // 삭제 확인
+  const isConfirmed = window.confirm('정말 이 서비스 그룹을 삭제하시겠습니까?')
+  if (!isConfirmed) return
+  
   try {
     const response = await serviceApi.deleteServiceGroup(serviceGroupId)
     const data = response.data.data

--- a/src/views/admin/ServiceManagement.vue
+++ b/src/views/admin/ServiceManagement.vue
@@ -1,7 +1,6 @@
 <script setup>
 import AdminLayout from '@/components/AdminLayout.vue'
 import Breadcrumb from '@/components/Breadcrumb.vue'
-import Modal from '@/components/Modal.vue'
 import { reactive, computed, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import draggable from 'vuedraggable'
@@ -13,33 +12,58 @@ const serviceGroupId = route.params.serviceGroupId
 const serviceGroupName = decodeURIComponent(route.query.serviceGroupName || '')
 const services = reactive([])
 
-const breadcrumbItems = [
-  { label: '서비스 그룹', path: `admin/service-group-managation` },
-  { label: serviceGroupName, path: `` },
-]
+const breadcrumbItems = computed(() => [
+  { label: '서비스 그룹', path: '/admin/service-group-managation' },
+  { label: decodeURIComponent(route.query.serviceGroupName || ''), path: '' },
+])
 
 const selectedService = reactive({
-  serviceId: null,
-  serviceName: '',
+  id: null,
+  name: '',
   startTime: '',
   endTime: '',
   capacity: 0,
-  location: '',
   description: '',
+  customFields: [],
 })
 
 const showDetailModal = ref(false)
 
 // 모달 열기
-const viewServiceDetail = (id) => {
+const viewServiceDetail = async (id) => {
   const service = services.find((s) => s.id === id)
   if (service) {
     Object.assign(selectedService, service)
     showDetailModal.value = true
+
+    try {
+      const response = await serviceApi.getResourceCustomFieldAndValue(id)
+      selectedService.customFields = (response.data.data || []).map((field) => ({
+        fieldName: field.fieldName,
+        value: Array.isArray(field.values) ? field.values.join(', ') : field.values,
+      }))
+    } catch (error) {
+      console.error('커스텀 필드 조회 실패:', error)
+      selectedService.customFields = []
+    }
   }
 }
 
-const goToEditService = () => {}
+const goToEditService = (serviceId) => {
+  if (!serviceId) {
+    console.warn('서비스 ID가 없습니다.')
+    return
+  }
+
+  router.push({
+    name: 'ServiceEdit',
+    params: { serviceId },
+    query: {
+      serviceGroupId: serviceGroupId, // 그룹정보도 필요할 경우
+      serviceGroupName: serviceGroupName, 
+    },
+  })
+}
 
 // 상태별 computed
 const createStatusComputed = (statusName) =>
@@ -80,7 +104,7 @@ watch(
       getServiceList(newId)
     }
   },
-  { immediate: true } 
+  { immediate: true },
 )
 </script>
 
@@ -189,41 +213,53 @@ watch(
     </div>
 
     <Modal :open="showDetailModal">
-      <div class="service-image mb-4"></div>
+      <div class="modal-container">
+        <!-- <img class="resource-image-box" :src="selectedService.resourceImage" alt="리소스 이미지" /> -->
+        <img
+          class="resource-image-box"
+          src="https://image.fmkorea.com/files/attach/new4/20250110/7908807291_44021718_cc499aa70d44d0afe024a9295e6a6c23.jpg"
+          alt="djse"
+        />
 
-      <div class="info-row">
-        <span class="info-label font-semibold">서비스명:</span>
-        <span>{{ selectedService.serviceName }}</span>
-      </div>
+        <div class="resource-info-container">
+          <h2>{{ selectedService.name }}</h2>
 
-      <div class="info-row">
-        <span class="info-label font-semibold">시작시간:</span>
-        <span>{{ selectedService.startTime }}</span>
-      </div>
+          <div class="info-row">
+            <span class="info-label">시작시간</span>
+            <span>{{ selectedService.startTime }}</span>
+          </div>
 
-      <div class="info-row">
-        <span class="info-label font-semibold">종료시간:</span>
-        <span>{{ selectedService.endTime }}</span>
-      </div>
+          <div class="info-row">
+            <span class="info-label">종료시간</span>
+            <span>{{ selectedService.endTime }}</span>
+          </div>
 
-      <div class="info-row">
-        <span class="info-label font-semibold">인원수:</span>
-        <span>{{ selectedService.capacity }}</span>
-      </div>
+          <div class="info-row">
+            <span class="info-label">인원수</span>
+            <span>{{ selectedService.capacity }} 명</span>
+          </div>
 
-      <div class="info-row">
-        <span class="info-label font-semibold">장소:</span>
-        <span>{{ selectedService.location }}</span>
-      </div>
+          <div v-if="selectedService.customFields.length">
+            <div
+              v-for="(field, index) in selectedService.customFields"
+              :key="index"
+              class="info-row"
+            >
+              <span class="info-label">{{ field.fieldName }}</span>
+              <span>{{ field.value }}</span>
+            </div>
+          </div>
 
-      <div class="info-row">
-        <span class="info-label font-semibold">설명:</span>
-        <span>{{ selectedService.description }}</span>
-      </div>
+          <div class="service-info-description-container">
+            <span class="info-label">설명</span>
+            <p>{{ selectedService.description }}</p>
+          </div>
+        </div>
 
-      <div class="modal-footer">
-        <Button class="modal-btn" :theme="'gray'" @click="showDetailModal = false">닫기</Button>
-        <Button class="modal-btn" @click="goToEditService">수정</Button>
+        <div class="modal-footer">
+          <Button class="modal-btn" :theme="'gray'" @click="showDetailModal = false">닫기</Button>
+          <Button class="modal-btn" @click="goToEditService(selectedService.id)">수정</Button>
+        </div>
       </div>
     </Modal>
   </AdminLayout>
@@ -267,25 +303,53 @@ watch(
   @apply flex justify-between text-[12px] text-text border-b border-gray-line p-[13px];
 }
 .service-name {
-  @apply text-blue-600 hover:underline cursor-pointer text-[14px];
+  @apply text-blue-600 hover:font-medium hover:underline cursor-pointer text-[14px];
 }
 .service-image {
   @apply w-full h-40 bg-gray-200 rounded-md;
 }
 .info-row {
-  @apply flex gap-2 mb-2 items-center  min-w-[300px];
+  @apply flex gap-2 mb-2 items-center  min-w-[300px] text-[14px];
 }
 .info-label {
-  @apply w-24 text-gray-700 text-sm;
+  @apply w-24 text-[#535353] text-[14px];
 }
 .modal-footer {
-  @apply flex float-right gap-3 mt-2;
+  @apply flex float-right gap-1 mt-2 w-full justify-end;
 }
 .modal-btn {
-  @apply w-[130px] text-sm;
+  @apply w-[80px] text-sm rounded-[5px];
 }
 
 .service-name-container {
   @apply px-[14px] py-[10px];
+}
+
+.resource-image-box {
+  @apply w-full h-[220px] object-cover rounded-[5px];
+}
+
+.modal-container {
+  @apply w-[512px] max-h-[500px] flex flex-col overflow-y-auto;
+}
+
+.modal-container h2 {
+  @apply text-[18px] font-bold mt-[15px] mb-[15px];
+}
+
+.resource-info-container {
+  @apply p-[5px] flex-1;
+}
+
+.service-info-description-container {
+  @apply flex flex-col items-start gap-2
+}
+
+.service-info-description-container p {
+  @apply text-[14px] mb-[20px]
+}
+
+::-webkit-scrollbar-track {
+  background: #eeeeee;
 }
 </style>

--- a/src/views/admin/ServiceManagement.vue
+++ b/src/views/admin/ServiceManagement.vue
@@ -214,12 +214,7 @@ watch(
 
     <Modal :open="showDetailModal">
       <div class="modal-container">
-        <!-- <img class="resource-image-box" :src="selectedService.resourceImage" alt="리소스 이미지" /> -->
-        <img
-          class="resource-image-box"
-          src="https://image.fmkorea.com/files/attach/new4/20250110/7908807291_44021718_cc499aa70d44d0afe024a9295e6a6c23.jpg"
-          alt="djse"
-        />
+        <img class="resource-image-box" :src="selectedService.resourceImage" alt="리소스 이미지" />
 
         <div class="resource-info-container">
           <h2>{{ selectedService.name }}</h2>

--- a/src/views/admin/ServiceManagement.vue
+++ b/src/views/admin/ServiceManagement.vue
@@ -2,7 +2,7 @@
 import AdminLayout from '@/components/AdminLayout.vue'
 import Breadcrumb from '@/components/Breadcrumb.vue'
 import Modal from '@/components/Modal.vue'
-import { reactive, computed, ref, onMounted } from 'vue'
+import { reactive, computed, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import draggable from 'vuedraggable'
 import serviceApi from '@/services/admin/service_api.js'
@@ -73,9 +73,15 @@ const getServiceList = async (serviceGroupId) => {
   }
 }
 
-onMounted(() => {
-  getServiceList(serviceGroupId)
-})
+watch(
+  () => route.params.serviceGroupId,
+  (newId, oldId) => {
+    if (newId) {
+      getServiceList(newId)
+    }
+  },
+  { immediate: true } 
+)
 </script>
 
 <template>

--- a/src/views/admin/ServiceManagement.vue
+++ b/src/views/admin/ServiceManagement.vue
@@ -1,74 +1,22 @@
 <script setup>
 import AdminLayout from '@/components/AdminLayout.vue'
 import Breadcrumb from '@/components/Breadcrumb.vue'
-import Button from '@/components/Button.vue'
 import Modal from '@/components/Modal.vue'
-import { reactive, computed, ref } from 'vue'
+import { reactive, computed, ref, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import draggable from 'vuedraggable'
+import serviceApi from '@/services/admin/service_api.js'
 
 const route = useRoute()
 const router = useRouter()
 const serviceGroupId = route.params.serviceGroupId
 const serviceGroupName = decodeURIComponent(route.query.serviceGroupName || '')
-const serviceGroup = reactive({})
+const services = reactive([])
 
 const breadcrumbItems = [
   { label: '서비스 그룹', path: `admin/service-group-managation` },
   { label: serviceGroupName, path: `` },
 ]
-
-// 더미 서비스 데이터
-const services = reactive([
-  {
-    serviceId: 1,
-    adminName: '김아영 관리자',
-    serviceName: '회의실 B',
-    updatedAt: '2025.10.03',
-    status: 'upcoming',
-    startTime: '09:00',
-    endTime: '10:00',
-    capacity: 10,
-    location: 'B동 2층',
-    description: '회의실 B 예약',
-  },
-  {
-    serviceId: 2,
-    adminName: '유현경 관리자',
-    serviceName: '회의실 A',
-    updatedAt: '2025.10.03',
-    status: 'upcoming',
-    startTime: '10:30',
-    endTime: '11:30',
-    capacity: 8,
-    location: 'A동 1층',
-    description: '회의실 A 예약',
-  },
-  {
-    serviceId: 3,
-    adminName: '박철수 관리자',
-    serviceName: '회의실 C',
-    updatedAt: '2025.10.04',
-    status: 'in-progress',
-    startTime: '11:00',
-    endTime: '12:00',
-    capacity: 12,
-    location: 'C동 3층',
-    description: '회의실 C 예약',
-  },
-  {
-    serviceId: 4,
-    adminName: '이민호 관리자',
-    serviceName: '회의실 D',
-    updatedAt: '2025.10.01',
-    status: 'finished',
-    startTime: '13:00',
-    endTime: '14:00',
-    capacity: 5,
-    location: 'D동 4층',
-    description: '회의실 D 예약',
-  },
-])
 
 const selectedService = reactive({
   serviceId: null,
@@ -84,7 +32,7 @@ const showDetailModal = ref(false)
 
 // 모달 열기
 const viewServiceDetail = (id) => {
-  const service = services.find((s) => s.serviceId === id)
+  const service = services.find((s) => s.id === id)
   if (service) {
     Object.assign(selectedService, service)
     showDetailModal.value = true
@@ -93,25 +41,41 @@ const viewServiceDetail = (id) => {
 
 const goToEditService = () => {}
 
-// 상태별 computed 배열 + 상태 변경 시 로그(API 호출 시점)
+// 상태별 computed
 const createStatusComputed = (statusName) =>
   computed({
-    get: () => services.filter((s) => s.status === statusName),
+    get: () => services.filter((s) => s.status.toUpperCase() === statusName.toUpperCase()),
     set: (newList) => {
       newList.forEach((item) => {
-        const original = services.find((s) => s.serviceId === item.serviceId)
-        if (original && original.status !== statusName) {
+        const original = services.find((s) => s.id === item.id)
+        if (original && original.status.toUpperCase() !== statusName.toUpperCase()) {
           original.status = statusName
-          console.log(`${original.serviceName} 상태가 ${statusName}로 업데이트되었습니다.`)
-          // API 호출
+          console.log(`${original.name} 상태가 ${statusName}로 변경됨`)
+          // 필요시 API 호출
         }
       })
     },
   })
 
-const upcomingServices = createStatusComputed('upcoming')
-const inProgressServices = createStatusComputed('in-progress')
-const finishedServices = createStatusComputed('finished')
+const upcomingServices = createStatusComputed('UPCOMING')
+const inProgressServices = createStatusComputed('IN_PROGRESS')
+const finishedServices = createStatusComputed('FINISHED')
+
+// 서비스 리스트 조회
+const getServiceList = async (serviceGroupId) => {
+  try {
+    const response = await serviceApi.getServiceList(serviceGroupId)
+    console.log('서비스 리스트 응답 : ', response.data)
+    // 실제 배열은 resources
+    services.splice(0, services.length, ...response.data.data.resources)
+  } catch (error) {
+    console.log('서비스 리스트 조회 실패: ', error)
+  }
+}
+
+onMounted(() => {
+  getServiceList(serviceGroupId)
+})
 </script>
 
 <template>
@@ -142,18 +106,18 @@ const finishedServices = createStatusComputed('finished')
         <draggable
           v-model="upcomingServices"
           group="services"
-          :item-key="'serviceId'"
+          :item-key="'id'"
           class="service-list"
         >
           <template #item="{ element: s }">
             <div class="service">
               <div class="service-info">
-                <span>{{ s.adminName }}</span>
+                <span>{{ s.createdByName }} 관리자</span>
                 <span>{{ s.updatedAt }}</span>
               </div>
-              <div>
-                <span class="service-name" @click="viewServiceDetail(s.serviceId)">
-                  {{ s.serviceName }}
+              <div class="service-name-container">
+                <span class="service-name" @click="viewServiceDetail(s.id)">
+                  {{ s.name }}
                 </span>
               </div>
             </div>
@@ -176,12 +140,12 @@ const finishedServices = createStatusComputed('finished')
           <template #item="{ element: s }">
             <div class="service">
               <div class="service-info">
-                <span>{{ s.adminName }}</span>
+                <span>{{ s.createdByName }} 관리자</span>
                 <span>{{ s.updatedAt }}</span>
               </div>
-              <div>
-                <span class="service-name" @click="viewServiceDetail(s.serviceId)">
-                  {{ s.serviceName }}
+              <div class="service-name-container">
+                <span class="service-name" @click="viewServiceDetail(s.id)">
+                  {{ s.name }}
                 </span>
               </div>
             </div>
@@ -204,12 +168,12 @@ const finishedServices = createStatusComputed('finished')
           <template #item="{ element: s }">
             <div class="service">
               <div class="service-info">
-                <span>{{ s.adminName }}</span>
+                <span>{{ s.createdByName }} 관리자</span>
                 <span>{{ s.updatedAt }}</span>
               </div>
-              <div>
-                <span class="service-name" @click="viewServiceDetail(s.serviceId)">
-                  {{ s.serviceName }}
+              <div class="service-name-container">
+                <span class="service-name" @click="viewServiceDetail(s.id)">
+                  {{ s.name }}
                 </span>
               </div>
             </div>
@@ -273,31 +237,31 @@ const finishedServices = createStatusComputed('finished')
   @apply flex gap-3 h-full;
 }
 .status-container {
-  @apply grow flex flex-col gap-2;
+  @apply grow flex flex-col bg-[#F4F4F4] rounded-[5px] min-h-[550px] w-[480px];
 }
 .status {
-  @apply flex bg-gray-300 rounded-md px-3 py-2 font-normal items-center;
+  @apply flex bg-gray-deep rounded-tl-[5px] rounded-tr-[5px] px-[15px] py-[12px] font-medium items-center text-[14px];
 }
 .status-upcoming {
-  @apply rounded-full w-4 h-4 mr-2 bg-blue-300 border-2 border-blue-500;
+  @apply rounded-full w-4 h-4 mr-3 bg-blue-300 border-2 border-blue-500;
 }
 .status-in-progress {
-  @apply rounded-full w-4 h-4 mr-2 bg-green-300 border-2 border-green-500;
+  @apply rounded-full w-4 h-4 mr-3 bg-green-300 border-2 border-green-500;
 }
 .status-finished {
-  @apply rounded-full w-4 h-4 mr-2 bg-red-300 border-2 border-red-500;
+  @apply rounded-full w-4 h-4 mr-3 bg-red-300 border-2 border-red-500;
 }
 .service-list {
-  @apply bg-gray-50 p-3 rounded-md flex flex-col gap-2 h-full overflow-y-auto;
+  @apply mx-[10px] my-[15px] rounded-md flex flex-col gap-2 h-full overflow-y-auto;
 }
 .service {
-  @apply bg-white rounded-md p-2 hover:shadow-md cursor-pointer;
+  @apply bg-white rounded-md cursor-pointer;
 }
 .service-info {
-  @apply flex justify-between text-sm text-gray-700 mb-1;
+  @apply flex justify-between text-[12px] text-text border-b border-gray-line p-[13px];
 }
 .service-name {
-  @apply text-blue-600 hover:underline cursor-pointer;
+  @apply text-blue-600 hover:underline cursor-pointer text-[14px];
 }
 .service-image {
   @apply w-full h-40 bg-gray-200 rounded-md;
@@ -313,5 +277,9 @@ const finishedServices = createStatusComputed('finished')
 }
 .modal-btn {
   @apply w-[130px] text-sm;
+}
+
+.service-name-container {
+  @apply px-[14px] py-[10px];
 }
 </style>


### PR DESCRIPTION
## #️⃣ Issue Number

- #146 

<br />

## 📝 요약(Summary)

서비스 수정 페이지는 서연이 언니가 생성 페이지 API 연결하면 이어받아서 하는 게 더 빨리 끝낼 수 있을 거 같아서 틀만 옮겨두었습니다!

서비스 그룹 페이지 관련해서 아래 부분들을 수정했습니다.

### ✅ 커스텀 필드 데이터 타입 한글로 변경
   서비스 그룹 생성 페이지에서 커스텀 필드 추가했을 때 데이터 타입명이 영어로 뜨는 문제가 있었는데 한글로 변경했습니다.

### ✅ 서비스 그룹 삭제 시 confirm창 띄우기
   서비스 그룹 관리 페이지에서 서비스 그룹을 삭제할 때 confirm창을 띄워서 정말 삭제를 원하는 건지 확인을 합니다.

### ✅ 서비스 그룹 생성 후 페이지 이동
   서비스 그룹 생성 후 페이지가 이동하지 않는 문제 해결했습니다. (경로 문제)

### ✅ 라디오 초기값 설정
   서비스 그룹 생성 페이지에서 radio 버튼에 초기값이 설정되지 않는 문제 해결했습니다.

### ✅ 서비스 관리 페이지 디자인 수정
   
<img width="1915" height="878" alt="image" src="https://github.com/user-attachments/assets/bf02f155-8c92-436a-bec6-679016263033" />

<img width="1004" height="804" alt="image" src="https://github.com/user-attachments/assets/de896037-a026-4341-90c0-2d41fc8fa260" />

### ✅ 브레드크럼 연결
서비스 생성 페이지는 서연이 언니가 작업 중일 것 같아서 연결 안 했어요!

- 서비스 관리 페이지

   <img width="413" height="131" alt="image" src="https://github.com/user-attachments/assets/79fd588b-b2e4-4e71-8518-358e44d9ea8b" />

- 서비스 수정 페이지

   <img width="459" height="40" alt="image" src="https://github.com/user-attachments/assets/7108c14c-6b79-4f74-8a88-c00ca3237891" />

<br />