### PR TITLE
[Feat] 관리자 관리 기능 구현 및 페이지네이션 리팩토링

### DIFF
--- a/src/components/AccountManageModal.vue
+++ b/src/components/AccountManageModal.vue
@@ -108,7 +108,7 @@ const handleEditSubmit = async () => {
     authStore.updateUser(updatedData)
 
     // 서버에서 최신 데이터 가져오기
-    const response = await adminApi.getManagerInfo()
+    const response = await adminApi.getMyProfile() // ← getManagerInfo → getMyProfile
     Object.assign(props.userData, response.data) // props.userData 직접 업데이트
 
     // 모드 전환

--- a/src/components/AdminLayout.vue
+++ b/src/components/AdminLayout.vue
@@ -13,7 +13,7 @@ const authStore = useAuthStore()
 
 async function openModal() {
   try {
-    const response = await adminApi.getManagerInfo()
+    const response = await adminApi.getMyProfile()
 
     if (response.data && response.data.data) {
       userData.value = response.data.data
@@ -156,9 +156,14 @@ onMounted(() => {
         <span class="sub-menu-label">Control</span>
         <div class="sub-menu-items-container">
           <router-link class="sub-menu-item" to="/admin/dashboard">전체 현황</router-link>
-          <router-link class="sub-menu-item" to="/admin/manager-management"
-            >관리자 관리</router-link
+          <!-- ADMIN만 관리자 관리 메뉴 표시 -->
+          <router-link
+            v-if="authStore.role === 'ADMIN'"
+            class="sub-menu-item"
+            to="/admin/manager-management"
           >
+            관리자 관리
+          </router-link>
           <router-link class="sub-menu-item" to="/admin/service-group-management"
             >서비스 그룹 관리</router-link
           >

--- a/src/plugin/axiosInterceptor.js
+++ b/src/plugin/axiosInterceptor.js
@@ -103,11 +103,6 @@ axiosInstance.interceptors.response.use(
       if (isLoggingOut) {
         return Promise.reject(error)
       }
-      
-      // 비밀번호 재설정 페이지는 예외 처리
-      if (currentPath.includes('/admin/firstPassword')) {
-        return Promise.reject(error)
-      }
 
       // refresh 요청 자체가 실패한 경우 → 즉시 로그아웃
       if (originalRequest.url === '/api/auth/refresh') {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -133,7 +133,7 @@ const router = createRouter({
       path: '/admin/manager-management',
       name: 'ManagerManagement',
       component: () => import('@/views/admin/ManagerManagement.vue'),
-      meta: { requiresAuth: true, role: 'ADMIN' },
+      meta: { requiresAuth: true, role: 'ADMIN', onlyAdmin: true },
     },
     {
       path: '/admin/notification',
@@ -298,11 +298,33 @@ const router = createRouter({
  * 전역 네비게이션 가드 (강화)
  * 1. 인증 상태 복원
  * 2. 인증 필요 페이지 접근 제어
- * 3. 역할 검증
+ * 3. 역할 검증 (Manager는 Admin 페이지 접근 가능)
  * 4. Company slug 검증 (USER만)
  */
 router.beforeEach(async (to, from, next) => {
   const authStore = useAuthStore()
+  
+  // ===== 역할 검증 헬퍼 함수 =====
+  
+  /**
+   * 역할 검증 헬퍼 함수
+   * - ADMIN 페이지는 ADMIN과 MANAGER 모두 허용
+   * - 나머지 페이지는 정확한 역할 일치 필요
+   */
+  const isRoleAllowed = (currentRole, requiredRole, onlyAdmin) => {
+    // onlyAdmin이 true면 ADMIN만 허용
+    if (onlyAdmin === true) {
+      return currentRole === 'ADMIN'
+    }
+  
+    // Admin 페이지는 ADMIN과 MANAGER 모두 허용
+    if (requiredRole === 'ADMIN' && (currentRole === 'ADMIN' || currentRole === 'MANAGER')) {
+      return true
+    }
+  
+    // 나머지는 정확히 일치해야 함
+    return currentRole === requiredRole
+  }
   
   // ===== 1. 인증 상태 복원 (localStorage 기반) =====
   authStore.checkAuth()
@@ -336,8 +358,9 @@ router.beforeEach(async (to, from, next) => {
       return next('/')
     }
 
-    // 3-2. 역할 불일치 검증
-    if (requiredRole && authStore.role !== requiredRole) {
+    // 3-2. 역할 불일치 검증 (Manager는 Admin 페이지 접근 가능)
+    const onlyAdmin = to.meta.onlyAdmin
+    if (requiredRole && !isRoleAllowed(authStore.role, requiredRole, onlyAdmin)) {
       console.warn('🚫 권한 불일치:', {
         required: requiredRole,
         current: authStore.role,
@@ -349,7 +372,7 @@ router.beforeEach(async (to, from, next) => {
       if (authStore.role === 'USER') {
         const slug = authStore.companySlug || 'default'
         return next(`/c/${slug}/service/list`)
-      } else if (authStore.role === 'ADMIN') {
+      } else if (authStore.role === 'ADMIN' || authStore.role === 'MANAGER') {
         return next('/admin/dashboard')
       } else if (authStore.role === 'SUPER') {
         return next('/super/dashboard')

--- a/src/services/admin/admin_api.js
+++ b/src/services/admin/admin_api.js
@@ -77,9 +77,10 @@ const resetPassword = async (payload) => {
 }
 
 /**
- * 내 정보 조회
+ * 내 프로필 조회
+ * - ADMIN/MANAGER 공통
  */
-const getManagerInfo = async (email, companyId) => {
+const getMyProfile = async () => {
   try {
     const response = await axiosInstance.get('/api/admins/me')
     return response.data
@@ -131,6 +132,68 @@ const logout = async () => {
   }
 }
 
+/**
+ * 매니저 목록 조회 (페이징)
+ */
+const getManagers = async (page = 0, size = 10) => {
+  try {
+    const response = await axiosInstance.get('/api/admins/managers', {
+      params: { page, size }
+    })
+    return response.data
+  } catch (error) {
+    console.error('매니저 목록 조회 실패', error)
+    throw error
+  }
+}
+
+/**
+ * 매니저 계정 생성
+ */
+const createManager = async (managerData) => {
+  try {
+    console.log('📤 매니저 생성 요청 데이터:', managerData)
+    const response = await axiosInstance.post('/api/admins/managers', managerData)
+    console.log('✅ 매니저 생성 성공:', response.data)
+    return response.data
+  } catch (error) {
+    console.error('❌ 매니저 생성 실패:', error)
+    console.error('📋 에러 상세:', error.response?.data)
+    console.error('📋 에러 상태:', error.response?.status)
+    throw error
+  }
+}
+
+/**
+ * 매니저 계정 삭제
+ */
+const deleteManager = async (managerId) => {
+  try {
+    const response = await axiosInstance.delete(`/api/admins/managers/${managerId}`)
+    return response.data
+  } catch (error) {
+    console.error('매니저 삭제 실패', error)
+    throw error
+  }
+}
+
+/**
+ * 매니저 정보 수정
+ * @param {number} managerId - 매니저 ID
+ * @param {Object} updateData - 수정할 정보
+ * @param {string} updateData.name - 이름
+ * @param {string} [updateData.phone] - 연락처 (선택)
+ */
+const updateManager = async (managerId, updateData) => {
+  try {
+    const response = await axiosInstance.patch(`/api/admins/managers/${managerId}`, updateData)
+    return response.data
+  } catch (error) {
+    console.error('매니저 수정 실패:', error)
+    throw error
+  }
+}
+
 
 export default {
   signUpAdmin,
@@ -140,8 +203,12 @@ export default {
   getSignUpStatus,
   login,
   resetPassword,
-  getManagerInfo,
+  getMyProfile,
   managerInfoEdit,
   managerInfoDelete,
   logout,
+  getManagers,
+  createManager,
+  deleteManager,
+  updateManager
 }

--- a/src/services/super/super_api.js
+++ b/src/services/super/super_api.js
@@ -60,6 +60,26 @@ const rejectCompany = async (companyId, rejectionReason) => {
   return response.data
 }
 
+/**
+ * 전체 관리자/매니저 조회
+ */
+const getAllAdmins = async (page = 0, size = 10, role = null, status = null) => {
+  const params = { page, size }
+  if (role) params.role = role
+  if (status) params.status = status
+  
+  const response = await axiosInstance.get('/api/admins', { params })
+  return response.data
+}
+
+/**
+ * 계정 상태 변경
+ */
+const updateAdminStatus = async (userId, status) => {
+  const response = await axiosInstance.patch(`/api/admins/${userId}/status`, { status })
+  return response.data
+}
+
 export default {
   // 인증
   login,
@@ -70,4 +90,10 @@ export default {
   getCompanyDetail,
   approveCompany,
   rejectCompany,
+
+  // 전체 관리자/매니저 조회
+  getAllAdmins,
+
+  // 계정 상태 변경
+  updateAdminStatus
 }

--- a/src/services/user/user_api.js
+++ b/src/services/user/user_api.js
@@ -216,6 +216,32 @@ const findEmail = async (findEmailData) => {
   }
 }
 
+/**
+ * 현재 로그인 사용자 정보 조회 (인증 확인용)
+ */
+const getCurrentUser = async () => {
+  try {
+    const response = await axiosInstance.get('/api/users/me')
+    return response.data
+  } catch (error) {
+    console.error('현재 사용자 정보 조회 실패:', error)
+    throw error
+  }
+}
+
+/**
+ * Access Token 갱신
+ */
+const refreshToken = async () => {
+  try {
+    const response = await axiosInstance.post('/api/users/refresh')
+    return response.data
+  } catch (error) {
+    console.error('Token 갱신 실패:', error)
+    throw error
+  }
+}
+
 export default {
   // 기업 정보
   getCompanyBySlug,
@@ -240,4 +266,10 @@ export default {
 
   // 아이디 찾기
   findEmail,
+
+  // 현재 로그인 사용자 정보 조회
+  getCurrentUser,
+
+  // Access Token 갱신
+  refreshToken 
 }

--- a/src/views/admin/ManagerManagement.vue
+++ b/src/views/admin/ManagerManagement.vue
@@ -1,22 +1,346 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, watch, onMounted } from 'vue'
 import AdminLayout from '@/components/AdminLayout.vue'
+import Toast from '@/components/Toast.vue'
+import PageNation from '@/components/PageNation.vue'
+import adminApi from '@/services/admin/admin_api'
 import Modal from '@/components/Modal.vue'
+import Button from '@/components/Button.vue'
 
 const isEditModalOpen = ref(false)
 const isAddModalOpen = ref(false)
 
-const openEditModal = () => {
-  isEditModalOpen.value = true
+/** 매니저 목록 */
+const managers = ref([])
+
+/** 페이징 정보 */
+const currentPage = ref(1) // 1-based로 변경 (프론트 표시용)
+const totalPages = ref(0) // 백엔드 totalPages (사용 안 함)
+const pageSize = ref(10)
+const totalElements = ref(0) // 전체 아이템 수
+
+/** 로딩 상태 */
+const loading = ref(false)
+
+/** 선택된 매니저 (수정/삭제용) */
+const selectedManager = ref(null)
+
+/** 수정 모드 활성화 여부 */
+const isEditMode = ref(false)
+
+/** 수정 폼 데이터 */
+const editForm = ref({
+  name: '',
+  phone: '',
+})
+
+/** Toast 알림 */
+const toastMessage = ref('')
+const toastType = ref('success')
+const showToast = ref(false)
+
+/** 매니저 추가 폼 데이터 */
+const newManager = ref({
+  name: '',
+  email: '',
+  phone: '',
+})
+
+// ========== 매니저 목록 조회 ==========
+
+/**
+ * 매니저 목록 조회
+ * @param {number} page - 페이지 번호 (1-based)
+ */
+const fetchManagers = async (page = 1) => {
+  loading.value = true
+  try {
+    // 백엔드는 0-based이므로 -1 처리
+    const backendPage = page - 1
+    const response = await adminApi.getManagers(backendPage, pageSize.value)
+
+    if (response.isSuccess && response.data) {
+      managers.value = response.data.managers || []
+      totalElements.value = response.data.totalElements || 0
+
+      // 프론트엔드는 1-based로 관리
+      currentPage.value = page
+    }
+  } catch (error) {
+    showToastMessage('매니저 목록을 불러오는데 실패했습니다.', 'error')
+  } finally {
+    loading.value = false
+  }
 }
 
+// ========== 컴포넌트 마운트 시 실행 ==========
+
+onMounted(() => {
+  fetchManagers()
+})
+
+// ========== 매니저 추가 ==========
+
+/**
+ * 매니저 추가 모달 열기
+ */
 const openAddModal = () => {
+  // 폼 초기화
+  newManager.value = {
+    name: '',
+    email: '',
+    phone: '',
+  }
   isAddModalOpen.value = true
 }
 
+/**
+ * 매니저 추가 모달 닫기
+ */
 const closeAddModal = () => {
   isAddModalOpen.value = false
 }
+
+/**
+ * 매니저 추가 처리
+ */
+const handleAddManager = async () => {
+  // 필수 항목 검사 (이름, 이메일만)
+  if (!newManager.value.name || !newManager.value.email) {
+    showToastMessage('이름과 이메일은 필수 항목입니다.', 'error')
+    return
+  }
+
+  // 이메일 형식 검증
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+  if (!emailRegex.test(newManager.value.email)) {
+    showToastMessage('올바른 이메일 형식을 입력해주세요.', 'error')
+    return
+  }
+
+  // 연락처 형식 검증 (입력된 경우에만)
+  if (newManager.value.phone && newManager.value.phone.trim()) {
+    // 백엔드 정규식에 맞춤: 01X-XXX(X)-XXXX
+    const phoneRegex = /^01(?:0|1|[6-9])-(?:\d{3}|\d{4})-\d{4}$/
+    if (!phoneRegex.test(newManager.value.phone)) {
+      showToastMessage('연락처는 010-1234-5678 형식으로 입력해주세요.', 'error')
+      return
+    }
+  }
+
+  loading.value = true
+  try {
+    // 빈 문자열을 null로 변환
+    const payload = {
+      name: newManager.value.name,
+      email: newManager.value.email,
+      phone:
+        newManager.value.phone && newManager.value.phone.trim() ? newManager.value.phone : null,
+    }
+
+    const response = await adminApi.createManager(payload)
+
+    // 백엔드 응답 구조: { isSuccess, code, message, data }
+    if (response.isSuccess) {
+      showToastMessage('매니저가 성공적으로 추가되었습니다. 이메일을 확인해주세요.', 'success')
+      closeAddModal()
+
+      // 목록을 첫 페이지로 갱신 (1-based)
+      currentPage.value = 1
+    } else {
+      showToastMessage(response.message || '매니저 추가에 실패했습니다.', 'error')
+    }
+  } catch (error) {
+    const errorMessage = error.response?.data?.message || '매니저 추가에 실패했습니다.'
+    showToastMessage(errorMessage, 'error')
+  } finally {
+    loading.value = false
+  }
+}
+
+// ========== 매니저 수정/삭제 ==========
+
+/**
+ * 매니저 상세 모달 열기
+ */
+const openEditModal = (manager) => {
+  selectedManager.value = { ...manager }
+
+  // 수정 폼 초기화
+  editForm.value = {
+    name: manager.name,
+    phone: manager.phone || '',
+  }
+
+  // 수정 모드 비활성화
+  isEditMode.value = false
+
+  isEditModalOpen.value = true
+}
+
+/**
+ * 매니저 삭제 처리
+ */
+const handleDeleteManager = async () => {
+  if (!selectedManager.value) return
+
+  // 삭제 확인
+  if (!confirm(`${selectedManager.value.name} 매니저를 삭제하시겠습니까?`)) {
+    return
+  }
+
+  loading.value = true
+  try {
+    const response = await adminApi.deleteManager(selectedManager.value.managerId)
+
+    // 백엔드 응답 구조: { isSuccess, code, message, data }
+    if (response.isSuccess) {
+      showToastMessage('매니저가 삭제되었습니다.', 'success')
+      isEditModalOpen.value = false
+      selectedManager.value = null
+
+      // 목록 갱신 (현재 페이지가 비었으면 이전 페이지로)
+      if (managers.value.length === 1 && currentPage.value > 1) {
+        currentPage.value = currentPage.value - 1
+      } else {
+        currentPage.value = currentPage.value // watch가 자동 호출
+      }
+    } else {
+      showToastMessage(response.message || '매니저 삭제에 실패했습니다.', 'error')
+    }
+  } catch (error) {
+    const errorMessage = error.response?.data?.message || '매니저 삭제에 실패했습니다.'
+    showToastMessage(errorMessage, 'error')
+  } finally {
+    loading.value = false
+  }
+}
+
+/**
+ * 수정 모드 활성화
+ */
+const enableEditMode = () => {
+  isEditMode.value = true
+}
+
+/**
+ * 수정 취소
+ */
+const cancelEdit = () => {
+  // 원래 데이터로 복원
+  editForm.value = {
+    name: selectedManager.value.name,
+    phone: selectedManager.value.phone || '',
+  }
+  isEditMode.value = false
+}
+
+/**
+ * 매니저 정보 수정 처리
+ */
+const handleUpdateManager = async () => {
+  if (!selectedManager.value) return
+
+  // 필수 항목 검사
+  if (!editForm.value.name) {
+    showToastMessage('이름은 필수 항목입니다.', 'error')
+    return
+  }
+
+  // 연락처 형식 검증 (입력된 경우에만)
+  if (editForm.value.phone && editForm.value.phone.trim()) {
+    const phoneRegex = /^01(?:0|1|[6-9])-(?:\d{3}|\d{4})-\d{4}$/
+    if (!phoneRegex.test(editForm.value.phone)) {
+      showToastMessage('연락처는 010-1234-5678 형식으로 입력해주세요.', 'error')
+      return
+    }
+  }
+
+  loading.value = true
+  try {
+    const payload = {
+      name: editForm.value.name,
+      phone: editForm.value.phone && editForm.value.phone.trim() ? editForm.value.phone : null,
+    }
+
+    const response = await adminApi.updateManager(selectedManager.value.managerId, payload)
+
+    if (response.isSuccess) {
+      showToastMessage('매니저 정보가 수정되었습니다.', 'success')
+      selectedManager.value.name = editForm.value.name
+      selectedManager.value.phone = editForm.value.phone || null
+      isEditMode.value = false
+
+      // 목록 갱신 (watch가 자동 호출하므로 값만 재할당)
+      currentPage.value = currentPage.value
+    } else {
+      showToastMessage(response.message || '매니저 수정에 실패했습니다.', 'error')
+    }
+  } catch (error) {
+    const errorMessage = error.response?.data?.message || '매니저 수정에 실패했습니다.'
+    showToastMessage(errorMessage, 'error')
+  } finally {
+    loading.value = false
+  }
+}
+
+// ========== Toast 알림 ==========
+
+/**
+ * Toast 메시지 표시
+ */
+const showToastMessage = (message, type = 'success') => {
+  toastMessage.value = message
+  toastType.value = type
+  showToast.value = true
+
+  setTimeout(() => {
+    showToast.value = false
+  }, 3000)
+}
+
+// ========== 유틸리티 함수 ==========
+
+/**
+ * 계정 상태 텍스트 변환
+ */
+const getStatusText = (status) => {
+  const statusMap = {
+    ACTIVE: '활성',
+    INACTIVE: '비활성',
+    SUSPENDED: '정지',
+    DELETED: '삭제됨',
+  }
+  return statusMap[status] || status
+}
+
+/**
+ * 날짜 포맷 변환
+ */
+const formatDate = (dateString) => {
+  if (!dateString) return '-'
+  const date = new Date(dateString)
+  return date.toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+// ========== 컴포넌트 마운트 시 실행 ==========
+
+/**
+ * 페이지 변경 감지
+ */
+watch(currentPage, (newPage) => {
+  fetchManagers(newPage)
+})
+
+onMounted(() => {
+  fetchManagers()
+})
 </script>
 
 <template>
@@ -26,58 +350,129 @@ const closeAddModal = () => {
       <span>관리자 관리</span>
     </div>
 
-    <!-- 매니저 목록 컴포넌트 -->
-    <div class="manage-list-container">
+    <!-- 로딩 상태 -->
+    <div v-if="loading" class="loading-container">
+      <p>로딩 중...</p>
+    </div>
+
+    <!-- 매니저 목록 -->
+    <div v-else class="manage-list-container">
       <!-- 매니저 추가 버튼 -->
       <div class="manage-add-button-container card" @click="openAddModal">
         <img src="/public/assets/icons/ic-plus-circle.png" alt="매니저 추가" />
       </div>
 
       <!-- 매니저 정보 카드 -->
-      <div class="manager-info-card card" @click="openEditModal">
+      <div
+        v-for="manager in managers"
+        :key="manager.managerId"
+        class="manager-info-card card"
+        @click="openEditModal(manager)"
+      >
         <div class="card-top">
-          <span>김아영</span>
-          <img src="/public/assets/icons/ic-delete-trash.png" alt="매니저 삭제" />
+          <span>{{ manager.name }}</span>
         </div>
 
         <div class="manager-info-row">
           <img src="/public/assets/icons/ic-email.png" alt="이메일" />
-          <span>DK8IJE32@gmail.com</span>
+          <span>{{ manager.email }}</span>
         </div>
         <div class="manager-info-row">
           <img src="/public/assets/icons/ic-phone.png" alt="연락처" />
-          <span>010-1234-5678</span>
+          <span>{{ manager.phone || '미등록' }}</span>
         </div>
+      </div>
+
+      <!-- 매니저 없을 때 -->
+      <div v-if="managers.length === 0" class="empty-state">
+        <p>등록된 매니저가 없습니다.</p>
       </div>
     </div>
 
-    <!-- 관리자 카드 클릭 시 뜨는 모달 -->
+    <!-- 페이징 -->
+    <PageNation
+      v-if="totalElements > 0"
+      v-model="currentPage"
+      :total-items="totalElements"
+      :items-per-page="pageSize"
+      :max-visible-pages="5"
+    />
+
+    <!-- 매니저 상세 모달 (조회/수정) -->
     <Modal :open="isEditModalOpen" @close="isEditModalOpen = false">
-      <div class="edit-modal-container">
+      <div class="edit-modal-container" v-if="selectedManager">
         <div class="manager-profile-image">
           <img src="/public/assets/icons/ic-manager-profile.png" alt="관리자 프로필 이미지" />
         </div>
-        <div class="manager-name">
-          <input type="text" />
-          <span>관리자</span>
-        </div>
-        <div class="manager-info-modal">
-          <span>이메일</span>
-          <p>test01@test.com</p>
-        </div>
-        <div class="manager-info-modal">
-          <span>연락처</span>
-          <input type="text" />
-        </div>
-        <div class="edit-modal-button-container">
-          <Button class="button-px" theme="gray">계정삭제</Button>
-          <Button class="button-px">수정</Button>
-        </div>
+
+        <!-- 조회 모드 -->
+        <template v-if="!isEditMode">
+          <div class="manager-name">
+            <span class="name-text">{{ selectedManager.name }}</span>
+            <span class="role-badge">관리자</span>
+          </div>
+          <div class="manager-info-modal">
+            <span>이메일</span>
+            <p>{{ selectedManager.email }}</p>
+          </div>
+          <div class="manager-info-modal">
+            <span>연락처</span>
+            <p>{{ selectedManager.phone || '미등록' }}</p>
+          </div>
+          <div class="manager-info-modal">
+            <span>계정 상태</span>
+            <p>{{ getStatusText(selectedManager.status) }}</p>
+          </div>
+          <div class="manager-info-modal">
+            <span>가입일</span>
+            <p>{{ formatDate(selectedManager.createdAt) }}</p>
+          </div>
+
+          <div class="edit-modal-button-container">
+            <Button class="button-px" theme="gray" @click="handleDeleteManager">계정삭제</Button>
+            <Button class="button-px" theme="light" @click="enableEditMode">수정하기</Button>
+            <Button class="button-px" @click="isEditModalOpen = false">닫기</Button>
+          </div>
+        </template>
+
+        <!-- 수정 모드 -->
+        <template v-else>
+          <div class="manager-name-edit">
+            <span class="name-text">정보 수정</span>
+          </div>
+
+          <div class="input-field-container-edit">
+            <div class="input-field-item">
+              <label>이름 <span>*</span></label>
+              <input v-model="editForm.name" type="text" placeholder="이름을 입력해주세요." />
+            </div>
+            <div class="input-field-item">
+              <label>이메일</label>
+              <input :value="selectedManager.email" type="email" disabled class="disabled-input" />
+            </div>
+            <div class="input-field-item">
+              <label>연락처</label>
+              <input
+                v-model="editForm.phone"
+                type="text"
+                placeholder="010-1234-5678"
+                maxlength="13"
+              />
+            </div>
+          </div>
+
+          <div class="edit-modal-button-container">
+            <Button class="button-px" theme="gray" @click="cancelEdit">취소</Button>
+            <Button class="button-px" @click="handleUpdateManager" :disabled="loading">
+              {{ loading ? '처리중...' : '수정완료' }}
+            </Button>
+          </div>
+        </template>
       </div>
     </Modal>
 
-    <!-- 관리자 추가 버튼 클릭 시 뜨는 모달 -->
-    <Modal :open="isAddModalOpen" @close="isAddModalOpen = false">
+    <!-- 매니저 추가 모달 -->
+    <Modal :open="isAddModalOpen" @close="closeAddModal" class="manager-add-modal">
       <div class="add-modal-container">
         <h3>관리자 추가</h3>
         <p>
@@ -88,24 +483,42 @@ const closeAddModal = () => {
         <div class="input-field-container">
           <div class="input-field-item">
             <label>이름 <span>*</span></label>
-            <input type="text" placeholder="관리자의 이름을 입력해주세요." />
+            <input
+              v-model="newManager.name"
+              type="text"
+              placeholder="관리자의 이름을 입력해주세요."
+            />
           </div>
           <div class="input-field-item">
             <label>이메일 <span>*</span></label>
-            <input type="email" placeholder="관리자의 이메일을 입력해주세요." />
+            <input
+              v-model="newManager.email"
+              type="email"
+              placeholder="관리자의 이메일을 입력해주세요."
+            />
           </div>
           <div class="input-field-item">
-            <label>연락처 <span>*</span></label>
-            <input type="phone" placeholder="관리자의 연락처를 입력해주세요." />
+            <label>연락처</label>
+            <input
+              v-model="newManager.phone"
+              type="text"
+              placeholder="010-1234-5678 (선택사항)"
+              maxlength="13"
+            />
           </div>
         </div>
 
         <div class="add-modal-button-container">
           <Button class="button-px" theme="gray" @click="closeAddModal">취소</Button>
-          <Button class="button-px">추가하기</Button>
+          <Button class="button-px" @click="handleAddManager" :disabled="loading">
+            {{ loading ? '처리중...' : '추가하기' }}
+          </Button>
         </div>
       </div>
     </Modal>
+
+    <!-- Toast 알림 -->
+    <Toast v-if="showToast" :message="toastMessage" :type="toastType" />
   </AdminLayout>
 </template>
 
@@ -193,6 +606,7 @@ const closeAddModal = () => {
 }
 
 /* 관리자 추가 모달 스타일 */
+
 .add-modal-container {
   @apply px-[30px] py-[20px] flex flex-col;
 }
@@ -202,7 +616,7 @@ h3 {
 }
 
 .add-modal-container p {
-  @apply text-[12px] text-gray-dark;
+  @apply text-[12px] text-gray-dark max-w-sm;
 }
 
 .input-field-container {
@@ -235,5 +649,45 @@ label {
 
 .button-px {
   @apply px-0;
+}
+
+.loading-container {
+  @apply flex justify-center items-center py-[100px] text-gray-dark;
+}
+
+.empty-state {
+  @apply col-span-full flex justify-center items-center text-gray-dark w-full h-[200px];
+}
+
+.name-text {
+  @apply text-[18px] font-medium;
+}
+
+.role-badge {
+  @apply text-[14px] text-gray-dark;
+}
+
+.edit-modal-container .manager-info-modal p {
+  @apply flex-1;
+}
+
+.manager-name-edit {
+  @apply flex items-center gap-2 mt-[18px] mb-[25px] px-[8px];
+}
+
+.input-field-container-edit {
+  @apply flex flex-col gap-5;
+}
+
+.disabled-input {
+  @apply bg-gray-200 cursor-not-allowed text-gray-dark;
+}
+
+.edit-modal-button-container button:nth-child(2) {
+  @apply flex-1;
+}
+
+.edit-modal-button-container button:nth-child(3) {
+  @apply flex-1;
 }
 </style>


### PR DESCRIPTION
## #️⃣ Issue Number

- #12 

## 📝 요약(Summary)

- 매니저 CRUD 완성 (조회/추가/수정/삭제)
- 페이지네이션 로직 개선 (0-based to 1-based 변환)
- 관리자 전용 메뉴 및 라우트 가드 추가

## 세부 구현
### 매니저 관리 (ManagerManagement.vue)
- 목록 조회 API 연동 및 페이징 처리
- 매니저 추가 모달 (이메일 자동 발송)
- 매니저 수정 모달 (조회 모드 / 수정 모드 토글)
- 매니저 삭제 기능 (확인 후 처리)
- 폼 검증 (이메일, 연락처 형식 체크)
- 비밀번호 재설정 페이지 예외 처리

## 📸스크린샷 (선택)

## 💬 공유사항

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->