### PR TITLE
[Feat] 매니저 관리 기능 및 인증 인터셉터 개선 #12

### DIFF
--- a/src/plugin/axiosInterceptor.js
+++ b/src/plugin/axiosInterceptor.js
@@ -176,6 +176,16 @@ axiosInstance.interceptors.response.use(
       console.error('💥 서버 오류가 발생했습니다.')
     }
 
+    // ===== 400 Bad Request: 비즈니스 로직 에러 =====
+    if (error.response?.status === 400) {
+      const { code, message } = error.response.data || {}
+      
+      // 에러 코드별 로깅 (디버깅용)
+      if (code >= 4000 && code < 5000) {
+        console.warn(`⚠️ 비즈니스 에러 [${code}]:`, message)
+      }
+    }
+
     return Promise.reject(error)
   }
 )

--- a/src/views/admin/ManagerManagement.vue
+++ b/src/views/admin/ManagerManagement.vue
@@ -1,7 +1,6 @@
 <script setup>
 import { ref, watch, onMounted } from 'vue'
 import AdminLayout from '@/components/AdminLayout.vue'
-import Toast from '@/components/Toast.vue'
 import PageNation from '@/components/PageNation.vue'
 import adminApi from '@/services/admin/admin_api'
 import Modal from '@/components/Modal.vue'
@@ -34,11 +33,6 @@ const editForm = ref({
   phone: '',
 })
 
-/** Toast 알림 */
-const toastMessage = ref('')
-const toastType = ref('success')
-const showToast = ref(false)
-
 /** 매니저 추가 폼 데이터 */
 const newManager = ref({
   name: '',
@@ -67,7 +61,8 @@ const fetchManagers = async (page = 1) => {
       currentPage.value = page
     }
   } catch (error) {
-    showToastMessage('매니저 목록을 불러오는데 실패했습니다.', 'error')
+    console.error('❌ 매니저 목록 조회 실패:', error.response?.data)
+    alert('매니저 목록을 불러오는데 실패했습니다.')
   } finally {
     loading.value = false
   }
@@ -107,14 +102,14 @@ const closeAddModal = () => {
 const handleAddManager = async () => {
   // 필수 항목 검사 (이름, 이메일만)
   if (!newManager.value.name || !newManager.value.email) {
-    showToastMessage('이름과 이메일은 필수 항목입니다.', 'error')
+    alert('이름과 이메일은 필수 항목입니다.')
     return
   }
 
   // 이메일 형식 검증
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
   if (!emailRegex.test(newManager.value.email)) {
-    showToastMessage('올바른 이메일 형식을 입력해주세요.', 'error')
+    alert('올바른 이메일 형식을 입력해주세요.')
     return
   }
 
@@ -123,7 +118,7 @@ const handleAddManager = async () => {
     // 백엔드 정규식에 맞춤: 01X-XXX(X)-XXXX
     const phoneRegex = /^01(?:0|1|[6-9])-(?:\d{3}|\d{4})-\d{4}$/
     if (!phoneRegex.test(newManager.value.phone)) {
-      showToastMessage('연락처는 010-1234-5678 형식으로 입력해주세요.', 'error')
+      alert('연락처는 010-1234-5678 형식으로 입력해주세요.')
       return
     }
   }
@@ -141,18 +136,20 @@ const handleAddManager = async () => {
     const response = await adminApi.createManager(payload)
 
     // 백엔드 응답 구조: { isSuccess, code, message, data }
+    // 백엔드 응답 구조: { isSuccess, code, message, data }
     if (response.isSuccess) {
-      showToastMessage('매니저가 성공적으로 추가되었습니다. 이메일을 확인해주세요.', 'success')
+      alert('매니저가 성공적으로 추가되었습니다. 이메일을 확인해주세요.')
       closeAddModal()
 
       // 목록을 첫 페이지로 갱신 (1-based)
       currentPage.value = 1
     } else {
-      showToastMessage(response.message || '매니저 추가에 실패했습니다.', 'error')
+      alert(response.message || '매니저 추가에 실패했습니다.')
     }
   } catch (error) {
+    console.error('❌ 매니저 생성 실패:', error.response?.data)
     const errorMessage = error.response?.data?.message || '매니저 추가에 실패했습니다.'
-    showToastMessage(errorMessage, 'error')
+    alert(errorMessage)
   } finally {
     loading.value = false
   }
@@ -195,7 +192,7 @@ const handleDeleteManager = async () => {
 
     // 백엔드 응답 구조: { isSuccess, code, message, data }
     if (response.isSuccess) {
-      showToastMessage('매니저가 삭제되었습니다.', 'success')
+      alert('매니저가 삭제되었습니다.')
       isEditModalOpen.value = false
       selectedManager.value = null
 
@@ -206,11 +203,12 @@ const handleDeleteManager = async () => {
         currentPage.value = currentPage.value // watch가 자동 호출
       }
     } else {
-      showToastMessage(response.message || '매니저 삭제에 실패했습니다.', 'error')
+      alert(response.message || '매니저 삭제에 실패했습니다.')
     }
   } catch (error) {
+    console.error('❌ 매니저 삭제 실패:', error.response?.data)
     const errorMessage = error.response?.data?.message || '매니저 삭제에 실패했습니다.'
-    showToastMessage(errorMessage, 'error')
+    alert(errorMessage)
   } finally {
     loading.value = false
   }
@@ -243,7 +241,7 @@ const handleUpdateManager = async () => {
 
   // 필수 항목 검사
   if (!editForm.value.name) {
-    showToastMessage('이름은 필수 항목입니다.', 'error')
+    alert('이름은 필수 항목입니다.')
     return
   }
 
@@ -251,7 +249,7 @@ const handleUpdateManager = async () => {
   if (editForm.value.phone && editForm.value.phone.trim()) {
     const phoneRegex = /^01(?:0|1|[6-9])-(?:\d{3}|\d{4})-\d{4}$/
     if (!phoneRegex.test(editForm.value.phone)) {
-      showToastMessage('연락처는 010-1234-5678 형식으로 입력해주세요.', 'error')
+      alert('연락처는 010-1234-5678 형식으로 입력해주세요.')
       return
     }
   }
@@ -266,7 +264,7 @@ const handleUpdateManager = async () => {
     const response = await adminApi.updateManager(selectedManager.value.managerId, payload)
 
     if (response.isSuccess) {
-      showToastMessage('매니저 정보가 수정되었습니다.', 'success')
+      alert('매니저 정보가 수정되었습니다.')
       selectedManager.value.name = editForm.value.name
       selectedManager.value.phone = editForm.value.phone || null
       isEditMode.value = false
@@ -274,29 +272,15 @@ const handleUpdateManager = async () => {
       // 목록 갱신 (watch가 자동 호출하므로 값만 재할당)
       currentPage.value = currentPage.value
     } else {
-      showToastMessage(response.message || '매니저 수정에 실패했습니다.', 'error')
+      alert(response.message || '매니저 수정에 실패했습니다.')
     }
   } catch (error) {
+    console.error('❌ 매니저 수정 실패:', error.response?.data)
     const errorMessage = error.response?.data?.message || '매니저 수정에 실패했습니다.'
-    showToastMessage(errorMessage, 'error')
+    alert(errorMessage)
   } finally {
     loading.value = false
   }
-}
-
-// ========== Toast 알림 ==========
-
-/**
- * Toast 메시지 표시
- */
-const showToastMessage = (message, type = 'success') => {
-  toastMessage.value = message
-  toastType.value = type
-  showToast.value = true
-
-  setTimeout(() => {
-    showToast.value = false
-  }, 3000)
 }
 
 // ========== 유틸리티 함수 ==========
@@ -516,9 +500,6 @@ onMounted(() => {
         </div>
       </div>
     </Modal>
-
-    <!-- Toast 알림 -->
-    <Toast v-if="showToast" :message="toastMessage" :type="toastType" />
   </AdminLayout>
 </template>
 


### PR DESCRIPTION
## #️⃣ Issue Number

- #12 

## 📝 요약(Summary)

ADMIN이 매니저를 조회/추가/수정/삭제할 수 있는 관리 페이지를 구현하고, 인증 인터셉터를 개선하여 사용자 경험을 향상시켰습니다.


## 📸스크린샷 (선택)

## 💬 공유사항

- 매니저 추가 시 이메일로 임시 비밀번호 발송됨
- 연락처는 선택 입력 (010-XXXX-XXXX 형식)
- Silent Auth 모드로 헤더 인증 체크 시 알림 없음
- 로그인 페이지에서 401 에러 알림 제거로 UX 개선
- 페이징은 프론트엔드 1-based, 백엔드 0-based 처리