### PR TITLE
[Feat] 플랫폼 관리자 기업/계정/서비스 그룹 관리 UI 구현 #175

### DIFF
--- a/src/components/CompanyDetail.vue
+++ b/src/components/CompanyDetail.vue
@@ -1,6 +1,5 @@
 <script setup>
-import { defineProps } from 'vue'
-import Button from './Button.vue'
+import { defineProps, defineEmits } from 'vue'
 import { useRouter } from 'vue-router'
 
 const router = useRouter()
@@ -11,6 +10,32 @@ const props = defineProps({
     required: true,
   },
 })
+
+const emit = defineEmits(['approve', 'reject', 'suspend', 'activate'])
+
+/**
+ * 상태별 배지 클래스 반환
+ */
+const getStatusBadgeClass = (status) => {
+  const classes = {
+    PENDING: 'bg-yellow-100 text-yellow-800',
+    ACTIVE: 'bg-green-100 text-green-800',
+    SUSPENDED: 'bg-red-100 text-red-800',
+  }
+  return `px-2 py-1 rounded text-xs font-medium ${classes[status] || 'bg-gray-100 text-gray-800'}`
+}
+
+/**
+ * 상태 텍스트 반환
+ */
+const getStatusText = (status) => {
+  const map = {
+    PENDING: '승인 대기',
+    ACTIVE: '활성',
+    SUSPENDED: '정지',
+  }
+  return map[status] || status
+}
 
 /**
  * 관리자 계정 목록 페이지로 이동
@@ -74,6 +99,14 @@ const goToServiceGroupList = () => {
             <th>가입일</th>
             <td>{{ company.registrationDate }}</td>
           </tr>
+          <tr>
+            <th>상태</th>
+            <td>
+              <span :class="getStatusBadgeClass(company.status)">
+                {{ getStatusText(company.status) }}
+              </span>
+            </td>
+          </tr>
         </tbody>
       </table>
     </section>
@@ -103,7 +136,7 @@ const goToServiceGroupList = () => {
       </table>
 
       <!-- 관리자 계정 목록 버튼 -->
-      <div v-if="company.status" class="link-button" @click="goToManagerList">
+      <div v-if="company.status !== 'PENDING'" class="link-button" @click="goToManagerList">
         관리자 계정 목록
         <img src="/assets/icons/ic-arrow-outward.png" />
       </div>
@@ -112,7 +145,7 @@ const goToServiceGroupList = () => {
     <hr />
 
     <!-- 플랫폼 이용 현황 -->
-    <section v-if="company.status" class="section-block relative">
+    <section v-if="company.status !== 'PENDING'" class="section-block relative">
       <h3 class="section-title">플랫폼 이용 현황</h3>
       <table>
         <tbody>
@@ -137,18 +170,27 @@ const goToServiceGroupList = () => {
         <img src="/assets/icons/ic-arrow-outward.png" />
       </div>
     </section>
-    <div v-else>
-      <span class="section-title">추가 전달사항</span>
-      <span class="inline-note"
-        >승인/거절 시 해당 관리자에게 메일이 전송 됩니다. 관리자에게 보낼 메일에 추가적으로 전달할
-        사항이 있다면 입력해 주세요.</span
-      >
-      <textarea> </textarea>
-    </div>
-    <div class="button-container">
-      <Button class="deny-button">거절</Button>
-      <Button>승인</Button>
-    </div>
+
+    <hr />
+
+    <!-- 버튼 영역 -->
+    <section class="action-section">
+      <!-- PENDING: 승인/거절 버튼 -->
+      <div v-if="company.status === 'PENDING'" class="button-group">
+        <button @click="emit('reject')" class="button-reject">거절</button>
+        <button @click="emit('approve')" class="button-approve">승인</button>
+      </div>
+
+      <!-- ACTIVE: 정지 버튼 -->
+      <div v-else-if="company.status === 'ACTIVE'" class="button-group">
+        <button @click="emit('suspend')" class="button-suspend">서비스 정지</button>
+      </div>
+
+      <!-- SUSPENDED: 활성화 버튼 -->
+      <div v-else-if="company.status === 'SUSPENDED'" class="button-group">
+        <button @click="emit('activate')" class="button-activate">서비스 활성화</button>
+      </div>
+    </section>
   </div>
 </template>
 
@@ -165,9 +207,6 @@ const goToServiceGroupList = () => {
   @apply text-lg font-semibold text-gray-800 text-lg mb-2;
 }
 
-.inline-note {
-  @apply text-xs text-gray-dark ml-3;
-}
 table {
   @apply w-full text-left ml-3;
 }
@@ -196,19 +235,27 @@ td {
   @apply h-[16px];
 }
 
-textarea {
-  @apply bg-gray-line w-full h-[6rem] mt-3;
+.action-section {
+  @apply mt-6 pt-6;
 }
 
-.button-container {
+.button-group {
   @apply flex justify-center gap-3;
 }
 
-.deny-button {
-  @apply bg-gray-line text-gray-dark;
+.button-approve {
+  @apply px-6 py-2 rounded bg-primary text-white hover:bg-primary-hover transition-colors;
 }
 
-.deny-button:hover {
-  @apply bg-gray-deep;
+.button-reject {
+  @apply px-6 py-2 rounded bg-gray-600 text-white hover:bg-gray-700 transition-colors;
+}
+
+.button-suspend {
+  @apply px-6 py-2 rounded bg-red-600 text-white hover:bg-red-700 transition-colors;
+}
+
+.button-activate {
+  @apply px-6 py-2 rounded bg-green-600 text-white hover:bg-green-700 transition-colors;
 }
 </style>

--- a/src/services/super/super_api.js
+++ b/src/services/super/super_api.js
@@ -116,6 +116,30 @@ const updateManagerStatus = async (userId, status) => {
   return response.data
 }
 
+/**
+ * 특정 기업의 서비스 그룹 목록 조회
+ */
+const getCompanyResourceGroups = async (companyId) => {
+  const response = await axiosInstance.get(`/api/resource-group/company/${companyId}`)
+  return response.data
+}
+
+/**
+ * 서비스 그룹 활성화
+ */
+const activateResourceGroup = async (resourceGroupId) => {
+  const response = await axiosInstance.patch(`/api/resource-group/${resourceGroupId}/activate`)
+  return response.data
+}
+
+/**
+ * 서비스 그룹 비활성화
+ */
+const deactivateResourceGroup = async (resourceGroupId) => {
+  const response = await axiosInstance.patch(`/api/resource-group/${resourceGroupId}/deactivate`)
+  return response.data
+}
+
 export default {
   // 인증
   login,
@@ -135,5 +159,10 @@ export default {
   getAllAdmins,
 
   // 계정 상태 변경
-  updateAdminStatus
+  updateAdminStatus,
+
+  // 서비스 그룹 관리
+  getCompanyResourceGroups,
+  activateResourceGroup,
+  deactivateResourceGroup,
 }

--- a/src/views/admin/ManagerManagement.vue
+++ b/src/views/admin/ManagerManagement.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, watch, onMounted } from 'vue'
+import { ref, onMounted } from 'vue'
 import AdminLayout from '@/components/AdminLayout.vue'
 import PageNation from '@/components/PageNation.vue'
 import adminApi from '@/services/admin/admin_api'
@@ -143,6 +143,7 @@ const handleAddManager = async () => {
 
       // 목록을 첫 페이지로 갱신 (1-based)
       currentPage.value = 1
+      await fetchManagers(1)
     } else {
       alert(response.message || '매니저 추가에 실패했습니다.')
     }
@@ -273,7 +274,7 @@ const handleUpdateManager = async () => {
       isEditMode.value = false
 
       // 목록 갱신 (watch가 자동 호출하므로 값만 재할당)
-      currentPage.value = currentPage.value
+      await fetchManagers(currentPage.value)
     } else {
       alert(response.message || '매니저 수정에 실패했습니다.')
     }
@@ -317,13 +318,6 @@ const formatDate = (dateString) => {
 }
 
 // ========== 컴포넌트 마운트 시 실행 ==========
-
-/**
- * 페이지 변경 감지
- */
-watch(currentPage, (newPage) => {
-  fetchManagers(newPage)
-})
 
 onMounted(() => {
   fetchManagers()

--- a/src/views/super/CompanyDetailView.vue
+++ b/src/views/super/CompanyDetailView.vue
@@ -1,13 +1,12 @@
 <script setup>
 import { ref, onMounted } from 'vue'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import superApi from '@/services/super/super_api'
 import CompanyDetail from '@/components/CompanyDetail.vue'
 
 const route = useRoute()
+const router = useRouter()
 const company = ref(null)
-const isConfirmModalOpen = ref(false)
-const targetStatus = ref('')
 
 /**
  * 기업 상세 정보 조회
@@ -18,7 +17,6 @@ const fetchCompanyDetail = async () => {
 
     if (response && response.isSuccess && response.data) {
       company.value = response.data
-      console.log('✅ 기업 상세:', company.value)
     } else {
       company.value = null
     }
@@ -33,33 +31,99 @@ onMounted(() => {
 })
 
 /**
- * 서비스 정지 처리
+ * 기업 승인
  */
-const handleSuspend = () => {
-  targetStatus.value = 'SUSPENDED'
-  isConfirmModalOpen.value = true
-}
+const handleApprove = async () => {
+  const confirmed = confirm(
+    `'${company.value.companyName}'을 승인하시겠습니까?\n승인 시 해당 관리자에게 메일이 전송됩니다.`
+  )
+  if (!confirmed) return
 
-/**
- * 서비스 재개 처리
- */
-const handleActivate = () => {
-  targetStatus.value = 'ACTIVE'
-  isConfirmModalOpen.value = true
-}
-
-/**
- * 상태 변경 확정
- */
-const confirmStatusChange = async () => {
   try {
-    await superApi.updateCompanyStatus(company.value.companyId, targetStatus.value)
-    await fetchCompanyDetail()
-    isConfirmModalOpen.value = false
-    alert('상태가 변경되었습니다.')
+    const response = await superApi.approveCompany(company.value.companyId)
+    if (response.isSuccess) {
+      alert('기업이 승인되었습니다.')
+      await fetchCompanyDetail()
+    } else {
+      alert(response.message || '승인에 실패했습니다.')
+    }
   } catch (error) {
-    console.error('❌ 상태 변경 실패:', error)
-    alert('상태 변경에 실패했습니다.')
+    console.error('❌ 승인 실패:', error)
+    alert('승인 처리 중 오류가 발생했습니다.')
+  }
+}
+
+/**
+ * 기업 거절
+ */
+const handleReject = async () => {
+  const reason = prompt('거절 사유를 입력해주세요:')
+  if (!reason || reason.trim() === '') {
+    alert('거절 사유를 입력해야 합니다.')
+    return
+  }
+
+  const confirmed = confirm(
+    `'${company.value.companyName}'을 거절하시겠습니까?\n거절 시 해당 관리자에게 메일이 전송됩니다.`
+  )
+  if (!confirmed) return
+
+  try {
+    const response = await superApi.rejectCompany(company.value.companyId, reason)
+    if (response.isSuccess) {
+      alert('기업이 거절되었습니다.')
+      router.push('/super/companies/pending')
+    } else {
+      alert(response.message || '거절에 실패했습니다.')
+    }
+  } catch (error) {
+    console.error('❌ 거절 실패:', error)
+    alert('거절 처리 중 오류가 발생했습니다.')
+  }
+}
+
+/**
+ * 기업 정지
+ */
+const handleSuspend = async () => {
+  const confirmed = confirm(
+    `'${company.value.companyName}'을 정지하시겠습니까?\n` +
+      `정지하면 해당 기업의 서비스가 중단되고, 관리자/매니저가 로그인할 수 없게 됩니다.`
+  )
+  if (!confirmed) return
+
+  try {
+    const response = await superApi.updateCompanyStatus(company.value.companyId, 'SUSPENDED')
+    if (response.isSuccess) {
+      alert('기업이 정지되었습니다.')
+      await fetchCompanyDetail()
+    } else {
+      alert(response.message || '상태 변경에 실패했습니다.')
+    }
+  } catch (error) {
+    console.error('❌ 정지 실패:', error)
+    alert('상태 변경 중 오류가 발생했습니다.')
+  }
+}
+
+/**
+ * 기업 활성화
+ */
+const handleActivate = async () => {
+  const confirmed = confirm(`'${company.value.companyName}'을 활성화하시겠습니까?`)
+  if (!confirmed) return
+
+  try {
+    const response = await superApi.updateCompanyStatus(company.value.companyId, 'ACTIVE')
+    if (response.isSuccess) {
+      alert('기업이 활성화되었습니다.')
+      await fetchCompanyDetail()
+    } else {
+      alert(response.message || '상태 변경에 실패했습니다.')
+    }
+  } catch (error) {
+    console.error('❌ 활성화 실패:', error)
+    alert('상태 변경 중 오류가 발생했습니다.')
   }
 }
 
@@ -78,7 +142,7 @@ const transformCompanyData = (apiData) => {
     administrator: apiData.adminName,
     email: apiData.email,
     phone: apiData.phone,
-    status: apiData.status === 'ACTIVE',
+    status: apiData.status,
     serviceGroups: apiData.serviceGroupCount || 0,
     customers: apiData.userCount || 0,
     lastLogin: apiData.lastLoginAt ? formatDateTime(apiData.lastLoginAt) : '-',
@@ -112,19 +176,6 @@ const formatDateTime = (dateString) => {
     minute: '2-digit',
   })
 }
-
-/**
- * 상태 텍스트 변환
- */
-const getStatusText = (status) => {
-  const statusMap = {
-    ACTIVE: '활성',
-    SUSPENDED: '정지',
-    PENDING: '승인 대기',
-    REJECTED: '거절',
-  }
-  return statusMap[status] || status
-}
 </script>
 
 <template>
@@ -136,200 +187,24 @@ const getStatusText = (status) => {
 
     <!-- 기업 정보 표시 -->
     <div v-else>
-      <!-- 상단 헤더 -->
-      <div class="page-header">
-        <h1>{{ company.companyName }}</h1>
-        <div class="status-badge" :class="'status-' + company.status.toLowerCase()">
-          {{ getStatusText(company.status) }}
-        </div>
-      </div>
-
       <!-- CompanyDetail 컴포넌트 사용 -->
-      <CompanyDetail :company="transformCompanyData(company)">
-        <!-- 상태 변경 버튼 추가 (slot 사용) -->
-        <template #additional-section>
-          <div class="action-section">
-            <button v-if="company.status === 'ACTIVE'" @click="handleSuspend" class="btn-danger">
-              서비스 정지
-            </button>
-            <button
-              v-else-if="company.status === 'SUSPENDED'"
-              @click="handleActivate"
-              class="btn-primary"
-            >
-              서비스 재개
-            </button>
-          </div>
-        </template>
-      </CompanyDetail>
-    </div>
-
-    <!-- 확인 모달 -->
-    <div v-if="isConfirmModalOpen" class="modal-overlay" @click="isConfirmModalOpen = false">
-      <div class="modal-content" @click.stop>
-        <h3>상태 변경 확인</h3>
-        <p>
-          정말 {{ targetStatus === 'SUSPENDED' ? '서비스를 정지' : '서비스를 재개' }}하시겠습니까?
-        </p>
-        <div class="modal-buttons">
-          <button @click="confirmStatusChange" class="btn-confirm">확인</button>
-          <button @click="isConfirmModalOpen = false" class="btn-cancel">취소</button>
-        </div>
-      </div>
+      <CompanyDetail
+        :company="transformCompanyData(company)"
+        @approve="handleApprove"
+        @reject="handleReject"
+        @suspend="handleSuspend"
+        @activate="handleActivate"
+      />
     </div>
   </div>
 </template>
 
 <style scoped>
 .company-detail-view {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 24px;
+  @apply max-w-7xl mx-auto py-6;
 }
 
 .loading {
-  text-align: center;
-  padding: 48px;
-  color: #666;
-}
-
-.page-header {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  margin-bottom: 24px;
-}
-
-.page-header h1 {
-  font-size: 28px;
-  font-weight: bold;
-  margin: 0;
-}
-
-.status-badge {
-  padding: 6px 12px;
-  border-radius: 4px;
-  font-size: 14px;
-  font-weight: 600;
-}
-
-.status-active {
-  background: #d4edda;
-  color: #155724;
-}
-
-.status-suspended {
-  background: #f8d7da;
-  color: #721c24;
-}
-
-.status-pending {
-  background: #fff3cd;
-  color: #856404;
-}
-
-.action-section {
-  margin-top: 24px;
-  padding: 20px;
-  background: #f8f9fa;
-  border-radius: 8px;
-  display: flex;
-  justify-content: flex-end;
-  gap: 12px;
-}
-
-.btn-primary,
-.btn-danger {
-  padding: 10px 24px;
-  border: none;
-  border-radius: 6px;
-  font-size: 16px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s;
-}
-
-.btn-primary {
-  background: #007bff;
-  color: white;
-}
-
-.btn-primary:hover {
-  background: #0056b3;
-}
-
-.btn-danger {
-  background: #dc3545;
-  color: white;
-}
-
-.btn-danger:hover {
-  background: #c82333;
-}
-
-/* 모달 스타일 */
-.modal-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-}
-
-.modal-content {
-  background: white;
-  padding: 32px;
-  border-radius: 8px;
-  max-width: 400px;
-  width: 90%;
-}
-
-.modal-content h3 {
-  margin: 0 0 16px 0;
-  font-size: 20px;
-}
-
-.modal-content p {
-  margin: 0 0 24px 0;
-  color: #666;
-}
-
-.modal-buttons {
-  display: flex;
-  gap: 12px;
-  justify-content: flex-end;
-}
-
-.btn-confirm,
-.btn-cancel {
-  padding: 8px 20px;
-  border: none;
-  border-radius: 4px;
-  font-size: 14px;
-  cursor: pointer;
-  transition: all 0.2s;
-}
-
-.btn-confirm {
-  background: #007bff;
-  color: white;
-}
-
-.btn-confirm:hover {
-  background: #0056b3;
-}
-
-.btn-cancel {
-  background: #6c757d;
-  color: white;
-}
-
-.btn-cancel:hover {
-  background: #5a6268;
+  @apply text-center py-12 text-gray-500;
 }
 </style>

--- a/src/views/super/CompanyListView.vue
+++ b/src/views/super/CompanyListView.vue
@@ -17,10 +17,8 @@ const searchKeyword = ref('')
 // ===== 드롭다운 옵션 =====
 const statusOptions = [
   { value: '', label: '전체' },
-  { value: 'PENDING', label: '승인 대기' },
   { value: 'ACTIVE', label: '활성' },
   { value: 'SUSPENDED', label: '정지' },
-  { value: 'REJECTED', label: '승인 거절' },
 ]
 
 // ===== API 호출 =====
@@ -115,26 +113,28 @@ onMounted(() => {
 
 <template>
   <div class="page-container">
-    <h1 class="components-page-title">플랫폼 이용 기업 목록</h1>
+    <div class="header-with-controls">
+      <h3 class="page-title">플랫폼 이용 기업 목록</h3>
 
-    <div class="controls-bar">
-      <Dropdown
-        v-model="selectedStatus"
-        :options="statusOptions"
-        placeholder="전체"
-        @update:modelValue="handleStatusChange"
-        class="w-40"
-      />
+      <div class="controls-group">
+        <Input
+          v-model="searchKeyword"
+          type="text"
+          placeholder="기업명 또는 슬러그 검색"
+          @keyup.enter="handleSearch"
+          class="search-bar h-[35px]"
+        />
 
-      <Input
-        v-model="searchKeyword"
-        type="text"
-        placeholder="기업명 또는 슬러그 검색"
-        @keyup.enter="handleSearch"
-        class="search-bar"
-      />
+        <Dropdown
+          v-model="selectedStatus"
+          :options="statusOptions"
+          placeholder="전체"
+          @update:modelValue="handleStatusChange"
+          class="w-40 custom-dropdown"
+        />
 
-      <button @click="handleSearch" class="search-button">검색</button>
+        <button @click="handleSearch" class="search-button h-[35px]">검색</button>
+      </div>
     </div>
 
     <div class="components-white-container">
@@ -199,19 +199,30 @@ onMounted(() => {
 
 <style scoped>
 .page-container {
-  @apply flex flex-col gap-4;
+  @apply flex flex-col gap-1 py-5;
 }
 
-.controls-bar {
+/* 제목과 컨트롤을 같은 줄에 배치 */
+.header-with-controls {
+  @apply flex justify-between items-center;
+}
+
+/* 제목 스타일 */
+.page-title {
+  @apply text-2xl font-semibold text-text;
+}
+
+/* 검색/필터 그룹 */
+.controls-group {
   @apply flex gap-3 items-center;
 }
 
 .search-bar {
-  @apply ml-auto w-64;
+  @apply w-64;
 }
 
 .search-button {
-  @apply px-4 py-2 bg-primary text-white rounded hover:bg-primary-hover transition-colors;
+  @apply px-4 bg-primary text-white rounded hover:bg-primary-hover transition-colors;
 }
 
 .list-row {
@@ -228,5 +239,9 @@ onMounted(() => {
 
 .page-info {
   @apply text-sm text-gray-600;
+}
+
+.custom-dropdown :deep(.dropdown-selected-container) {
+  @apply !h-[35px] !pt-0 !pb-0 !flex !items-center;
 }
 </style>

--- a/src/views/super/ManagerListView.vue
+++ b/src/views/super/ManagerListView.vue
@@ -24,13 +24,11 @@ const fetchManagers = async () => {
     const response = await superApi.getCompanyManagers(companyId.value)
 
     if (response.isSuccess) {
-      managers.value = response.data.managers // ← .managers 추가
-      console.log('✅ 관리자 목록:', managers.value)
+      managers.value = response.data.managers
     } else {
       error.value = response.message || '데이터를 불러오는 데 실패했습니다.'
     }
   } catch (err) {
-    console.error('❌ 관리자 목록 조회 실패:', err)
     error.value = '서버와의 연결에 실패했습니다.'
   } finally {
     loading.value = false
@@ -57,7 +55,6 @@ const handleStatusChange = async (manager, newStatus) => {
       alert(`상태 변경에 실패했습니다: ${response.message}`)
     }
   } catch (err) {
-    console.error('❌ 상태 변경 실패:', err)
     alert('상태 변경 중 오류가 발생했습니다.')
   }
 }
@@ -72,6 +69,17 @@ const formatDateTime = (dateString) => {
 }
 
 /**
+ * 역할 뱃지 CSS 클래스 반환
+ */
+const getRoleBadgeClass = (role) => {
+  const roleMap = {
+    ADMIN: 'px-2 py-1 bg-blue-100 text-blue-800 rounded text-xs font-medium',
+    MANAGER: 'px-2 py-1 bg-gray-200 text-gray-800 rounded text-xs font-medium',
+  }
+  return roleMap[role] || 'px-2 py-1 bg-gray-100 text-gray-800 rounded text-xs font-medium'
+}
+
+/**
  * 역할 텍스트 변환
  */
 const getRoleText = (role) => {
@@ -79,15 +87,29 @@ const getRoleText = (role) => {
 }
 
 /**
+ * 상태 뱃지 CSS 클래스 반환
+ */
+const getStatusBadgeClass = (status) => {
+  const statusMap = {
+    ACTIVE: 'bg-green-100 text-green-800',
+    INACTIVE: 'bg-gray-100 text-gray-800',
+    SUSPENDED: 'bg-red-100 text-red-800',
+    DELETED: 'bg-red-100 text-red-800',
+  }
+  return `px-2 py-1 rounded text-xs font-medium ${statusMap[status] || 'bg-gray-100 text-gray-800'}`
+}
+
+/**
  * 상태 텍스트 변환
  */
 const getStatusText = (status) => {
-  const statusMap = {
+  const map = {
     ACTIVE: '활성',
-    INACTIVE: '비활성',
-    SUSPENDED: '정지',
+    INACTIVE: '승인대기',
+    SUSPENDED: ' 정지 ',
+    DELETED: ' 삭제 ',
   }
-  return statusMap[status] || status
+  return map[status] || status
 }
 
 onMounted(() => {
@@ -103,6 +125,7 @@ onMounted(() => {
       { label: '관리자 계정 목록' },
     ]"
   />
+  <span class="components-page-title">관리자 계정 목록</span>
 
   <div class="components-white-container">
     <!-- 로딩 상태 -->
@@ -139,12 +162,20 @@ onMounted(() => {
         <tbody>
           <tr v-for="manager in managers" :key="manager.userId">
             <td>{{ manager.name }}</td>
-            <td>{{ getRoleText(manager.role) }}</td>
-            <td>{{ manager.email }}</td>
-            <td>{{ manager.phone }}</td>
-            <td>{{ getStatusText(manager.status) }}</td>
-            <td>{{ formatDateTime(manager.createdAt) }}</td>
-            <td>{{ formatDateTime(manager.updatedAt) }}</td>
+            <td>
+              <span :class="getRoleBadgeClass(manager.role)">
+                {{ getRoleText(manager.role) }}
+              </span>
+            </td>
+            <td class="info-text">{{ manager.email }}</td>
+            <td class="info-text">{{ manager.phone || '-' }}</td>
+            <td>
+              <span :class="getStatusBadgeClass(manager.status)">
+                {{ getStatusText(manager.status) }}
+              </span>
+            </td>
+            <td class="info-text">{{ formatDateTime(manager.createdAt) }}</td>
+            <td class="info-text">{{ formatDateTime(manager.updatedAt) }}</td>
             <td>
               <div class="action-buttons">
                 <!-- ACTIVE 상태일 때 -->
@@ -166,6 +197,9 @@ onMounted(() => {
                 >
                   활성화
                 </Button>
+
+                <!-- INACTIVE 상태일 때는 버튼 없음 -->
+                <span v-else class="text-gray-400 text-sm">-</span>
               </div>
             </td>
           </tr>
@@ -192,5 +226,9 @@ onMounted(() => {
 
 .action-buttons {
   @apply flex gap-2 justify-center;
+}
+
+.info-text {
+  @apply text-[12px];
 }
 </style>

--- a/src/views/super/ServiceGroupListView.vue
+++ b/src/views/super/ServiceGroupListView.vue
@@ -1,81 +1,175 @@
 <script setup>
-import SuperBreadcrumb from '@/components/Breadcrumb.vue'
+import { ref, onMounted, computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import SuperBreadcrumb from '@/components/Breadcrumb.vue'
+import superApi from '@/services/super/super_api'
 
 const route = useRoute()
 const router = useRouter()
 
-const companyName = route.params.companyName
+// ===== 상태 관리 =====
+const rawServiceGroups = ref([])
+const loading = ref(false)
+const error = ref(null)
+const companyId = ref(route.params.companyId)
+const actionLoading = ref(false)
 
-const goToServiceList = (serviceGroupName) => {
-  router.push(`/super/companies/${encodeURIComponent(companyName)}/services/${serviceGroupName}`)
+/**
+ * 서비스 그룹 목록 조회
+ */
+const fetchServiceGroups = async () => {
+  loading.value = true
+  error.value = null
+
+  try {
+    const response = await superApi.getCompanyResourceGroups(companyId.value)
+
+    if (response.isSuccess) {
+      rawServiceGroups.value = response.data.resourceGroups || []
+    } else {
+      error.value = response.message || '데이터를 불러오는 데 실패했습니다.'
+    }
+  } catch (err) {
+    console.error('❌ 서비스 그룹 목록 조회 실패:', err)
+    error.value = '서버와의 연결에 실패했습니다.'
+  } finally {
+    loading.value = false
+  }
 }
 
-const serviceGroups = [
-  {
-    groupName: '회의실 예약',
-    groupCode: 'SRV001',
-    category: '예약/신청',
-    createdAt: '2025-01-02',
-    updatedAt: '2025-01-10',
-    status: '활성',
-    createdBy: '홍길동',
-    updatedBy: '김수현',
-  },
-  {
-    groupName: '출장 신청',
-    groupCode: 'SRV002',
-    category: '예약/신청',
-    createdAt: '2025-03-01',
-    updatedAt: '2025-03-05',
-    status: '활성',
-    createdBy: '이영희',
-    updatedBy: '박세진',
-  },
-  {
-    groupName: '교육 신청',
-    groupCode: 'SRV003',
-    category: '예약/신청',
-    createdAt: '2025-03-15',
-    updatedAt: '2025-03-18',
-    status: '활성',
-    createdBy: '박민수',
-    updatedBy: '최유리',
-  },
-  {
-    groupName: '휴가/연차 신청',
-    groupCode: 'SRV004',
-    category: '예약/신청',
-    createdAt: '2025-04-10',
-    updatedAt: '2025-04-15',
-    status: '활성',
-    createdBy: '최지훈',
-    updatedBy: '김보라',
-  },
-  {
-    groupName: '물품 신청',
-    groupCode: 'SRV005',
-    category: '예약/신청',
-    createdAt: '2025-05-02',
-    updatedAt: '2025-05-05',
-    status: '활성',
-    createdBy: '김나영',
-    updatedBy: '이승현',
-  },
-]
+/**
+ * API 데이터를 기존 구조로 변환
+ */
+const serviceGroups = computed(() => {
+  return rawServiceGroups.value.map((group) => {
+    return {
+      id: group.id,
+      groupName: group.name,
+      groupCode: group.groupCode || '-',
+      category: group.category || '-',
+      createdAt: formatDate(group.createdAt),
+      updatedAt: formatDate(group.updatedAt),
+      isActive: group.isActive,
+      createdBy: group.administrator,
+      updatedBy: group.updatedByName || '-',
+    }
+  })
+})
+
+/**
+ * 날짜 포맷팅 (YYYY-MM-DD)
+ */
+const formatDate = (dateString) => {
+  if (!dateString) return '-'
+  const date = new Date(dateString)
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+/**
+ * 상태별 배지 스타일 반환
+ */
+const getStatusBadgeClass = (isActive) => {
+  return isActive
+    ? 'px-2 py-1 rounded text-xs font-medium bg-green-100 text-green-800'
+    : 'px-2 py-1 rounded text-xs font-medium bg-yellow-100 text-yellow-800'
+}
+
+/**
+ * 상태 텍스트 반환
+ */
+const getStatusText = (isActive) => {
+  return isActive ? '활성' : '비활성'
+}
+
+/**
+ * 서비스 목록으로 이동
+ */
+const goToServiceList = (groupId) => {
+  router.push({
+    name: 'superServiceGroupDetail',
+    params: {
+      companyId: companyId.value,
+      serviceGroupId: groupId,
+    },
+  })
+}
+
+/**
+ * 상태 변경 처리
+ */
+const handleStatusChange = async (group) => {
+  const isActivating = !group.isActive
+  const actionText = isActivating ? '활성화' : '비활성화'
+  const warningText = isActivating 
+    ? '' 
+    : '\n비활성화하면 일반 사용자가 해당 서비스를 볼 수 없게 됩니다.'
+
+  const confirmed = confirm(
+    `'${group.groupName}'을(를) ${actionText}하시겠습니까?${warningText}`
+  )
+
+  if (!confirmed) return
+
+  actionLoading.value = true
+
+  try {
+    const response = isActivating
+      ? await superApi.activateResourceGroup(group.id)
+      : await superApi.deactivateResourceGroup(group.id)
+
+    if (response.isSuccess) {
+      alert(response.message || `서비스 그룹이 ${actionText}되었습니다.`)
+      await fetchServiceGroups()
+    } else {
+      alert(response.message || '상태 변경에 실패했습니다.')
+    }
+  } catch (err) {
+    console.error('❌ 상태 변경 실패:', err)
+    alert('서버와의 연결에 실패했습니다.')
+  } finally {
+    actionLoading.value = false
+  }
+}
 
 // 브레드크럼 항목
 const breadcrumbItems = [
   { label: '기업 목록', path: '/super/companies' },
-  { label: companyName, path: `/super/companies/${encodeURIComponent(companyName)}` },
+  { label: '기업 상세', path: `/super/companies/${companyId.value}` },
   { label: '서비스 그룹 목록' },
 ]
+
+onMounted(() => {
+  fetchServiceGroups()
+})
 </script>
 
 <template>
   <SuperBreadcrumb :items="breadcrumbItems" />
   <span class="components-page-title">서비스 그룹 목록</span>
-  <div class="components-white-container">
+
+  <!-- 로딩 상태 -->
+  <div v-if="loading" class="components-white-container">
+    <div class="loading-message">로딩 중...</div>
+  </div>
+
+  <!-- 에러 상태 -->
+  <div v-else-if="error" class="components-white-container">
+    <div class="error-message">
+      <p>{{ error }}</p>
+      <button @click="fetchServiceGroups" class="retry-button">다시 시도</button>
+    </div>
+  </div>
+
+  <!-- 데이터 없음 -->
+  <div v-else-if="serviceGroups.length === 0" class="components-white-container">
+    <div class="empty-message">등록된 서비스 그룹이 없습니다.</div>
+  </div>
+
+  <!-- 테이블 -->
+  <div v-else class="components-white-container">
     <div class="components-super-table-container">
       <table class="components-super-table">
         <thead>
@@ -88,12 +182,13 @@ const breadcrumbItems = [
             <th>상태</th>
             <th>생성자</th>
             <th>수정자</th>
+            <th>액션</th>
           </tr>
         </thead>
         <tbody>
           <tr v-for="(s, i) in serviceGroups" :key="i">
             <td>
-              <div class="service-link" @click="goToServiceList(s.groupName)">
+              <div class="service-link" @click="goToServiceList(s.id)">
                 {{ s.groupName }} <img src="/assets/icons/ic-arrow-outward.png" />
               </div>
             </td>
@@ -101,9 +196,22 @@ const breadcrumbItems = [
             <td>{{ s.category }}</td>
             <td>{{ s.createdAt }}</td>
             <td>{{ s.updatedAt }}</td>
-            <td>{{ s.status }}</td>
+            <td>
+              <span :class="getStatusBadgeClass(s.isActive)">
+                {{ getStatusText(s.isActive) }}
+              </span>
+            </td>
             <td>{{ s.createdBy }}</td>
             <td>{{ s.updatedBy }}</td>
+            <td>
+              <button
+                @click.stop="handleStatusChange(s)"
+                :disabled="actionLoading"
+                :class="s.isActive ? 'action-button-deactivate' : 'action-button-activate'"
+              >
+                {{ s.isActive ? '비활성화' : '활성화' }}
+              </button>
+            </td>
           </tr>
         </tbody>
       </table>
@@ -112,8 +220,18 @@ const breadcrumbItems = [
 </template>
 
 <style scoped>
-.service-group-list-container {
-  @apply bg-white rounded-md shadow p-8 mt-3 space-y-6 overflow-x-auto;
+.loading-message,
+.error-message,
+.empty-message {
+  @apply text-center py-12 text-gray-500;
+}
+
+.error-message p {
+  @apply text-red-600 mb-4;
+}
+
+.retry-button {
+  @apply px-4 py-2 bg-primary text-white rounded hover:bg-primary-hover transition-colors;
 }
 
 td img {
@@ -122,5 +240,18 @@ td img {
 
 .service-link {
   @apply flex items-center hover:underline cursor-pointer;
+}
+
+/* 액션 버튼 */
+.action-button-activate {
+  @apply px-3 py-1 text-sm rounded bg-green-600 text-white 
+         hover:bg-green-700 transition-colors disabled:opacity-50 
+         disabled:cursor-not-allowed;
+}
+
+.action-button-deactivate {
+  @apply px-3 py-1 text-sm rounded bg-gray-600 text-white 
+         hover:bg-gray-700 transition-colors disabled:opacity-50 
+         disabled:cursor-not-allowed;
 }
 </style>


### PR DESCRIPTION


## #️⃣ Issue Number

- #175 

## 📝 요약(Summary)

[기업 관리 UI]
- 기업 상세: 상태 배지 추가 (승인 대기/활성/정지)
- 상태별 조건부 버튼 렌더링 (PENDING: 승인/거절, ACTIVE: 정지, SUSPENDED: 활성화)
- CompanyDetail 컴포넌트: emit 기반 이벤트 처리
- confirm 알림창으로 상태 변경 확인

[서비스 그룹 관리 UI]
- 서비스 그룹 목록: 상태 배지 추가 (활성/비활성)
- 활성화/비활성화 버튼 추가
- 상태 변경 후 목록 자동 새로고침

[API]
- 서비스 그룹 활성화/비활성화: HTTP 메서드 GET → PATCH 변경
- API 경로 수정: /active/{id} → /{id}/activate

[공통]
- 상태 배지 스타일 통일 (Tailwind CSS)
- confirm 알림창 사용으로 UX 개선
- 상태 변경 후 즉시 반영

## 📸스크린샷 (선택)

## 💬 공유사항

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->